### PR TITLE
🌐 Tran: localize Contact page metadata

### DIFF
--- a/src/lib/i18n/de.json
+++ b/src/lib/i18n/de.json
@@ -371,7 +371,8 @@
 	},
 	"contact": {
 		"title": "Kontakt",
-		"description": "Du kannst mich unter"
+		"description": "Du kannst mich unter",
+		"meta_description": "Kontaktinformationen und Möglichkeiten, mich zu erreichen."
 	},
 	"ping": {
 		"title": "Ping",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -371,7 +371,8 @@
 	},
 	"contact": {
 		"title": "Contact",
-		"description": "You can contact me at"
+		"description": "You can contact me at",
+		"meta_description": "Contact information and ways to reach out to me."
 	},
 	"ping": {
 		"title": "Ping",

--- a/src/routes/contact/contact.svelte
+++ b/src/routes/contact/contact.svelte
@@ -2,11 +2,18 @@
 	import Heading from "$lib/components/typography/Heading.svelte";
 	import { links } from "$lib/config";
 	import { i18n } from "$lib/i18n/i18n.svelte";
+	import { PAGE_TITLE_SUFFIX } from "$lib/config";
 
+	/**
+	 * Localization optimization: Aligns the Contact page with the application's standard
+	 * metadata pattern by adding the PAGE_TITLE_SUFFIX and a localized meta description
+	 * for improved i18n and SEO.
+	 */
 </script>
 
 <svelte:head>
-	<title>{i18n.t('contact.title')}</title>
+	<title>{i18n.t('contact.title')}{PAGE_TITLE_SUFFIX}</title>
+	<meta name="description" content={i18n.t('contact.meta_description')} />
 </svelte:head>
 
 <div>


### PR DESCRIPTION
This PR improves the internationalization and SEO of the Contact page by aligning its metadata with the application's standard pattern.

Changes:
- In `src/routes/contact/contact.svelte`, the `<title>` now includes the `PAGE_TITLE_SUFFIX` and a new localized `<meta name="description">` has been added.
- New `meta_description` keys have been added to the `contact` namespace in `src/lib/i18n/en.json` and `src/lib/i18n/de.json`.
- An explanatory comment has been added to the script block of the Contact component to document the optimization.

These changes ensure that the Contact page has a consistent title format and a descriptive, localized snippet in search results and social shares.

---
*PR created automatically by Jules for task [6193808454117788528](https://jules.google.com/task/6193808454117788528) started by @dnnsmnstrr*