### PR TITLE
🌐 Tran: [improve sitemap localization]

### DIFF
--- a/src/lib/i18n/de.json
+++ b/src/lib/i18n/de.json
@@ -34,6 +34,8 @@
 		"sitemap": "Sitemap",
 		"experiment": "Experiment",
 		"slashes": "Slashes",
+		"timeline": "Zeitstrahl",
+		"log": "Änderungsprotokoll",
 		"quit": "Beenden",
 		"new_window": "Neues Fenster",
 		"close_window": "Fenster schließen",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -24,6 +24,8 @@
 		"sitemap": "Sitemap",
 		"experiment": "Experiment",
 		"slashes": "Slashes",
+		"timeline": "Timeline",
+		"log": "Changelog",
 		"hotkeys": "Hotkeys",
 		"redirects": "Redirects",
 		"terminal": "Terminal",

--- a/src/routes/sitemap/+page.svelte
+++ b/src/routes/sitemap/+page.svelte
@@ -7,6 +7,13 @@
 	import { formatDate } from '$lib/utils/helper';
 
 	let { data }: PageProps = $props();
+
+	/*
+	 * The common namespace in i18n files is used to dynamically translate
+	 * page slugs in the sitemap. If a slug (e.g., 'timeline', 'log') is
+	 * missing from the common namespace, it falls back to a formatted version
+	 * of the technical slug.
+	 */
 </script>
 
 <svelte:head>


### PR DESCRIPTION
💡 What: Added 'timeline' and 'log' translation keys to the common namespace in both English and German locales. Added an explanatory comment to the sitemap component.

🎯 Why: The sitemap and global layout page title logic rely on the common namespace to localize route slugs. Previously, routes like /timeline and /log fell back to technical slugs because they were missing from the common namespace.

🔬 Measurement: Verified that the Sitemap correctly displays "Zeitstrahl" instead of "Timeline" when the language is set to German via Playwright and manual inspection. Verified JSON validity and passed unit tests.

---
*PR created automatically by Jules for task [4659514232473166186](https://jules.google.com/task/4659514232473166186) started by @dnnsmnstrr*