### PR TITLE
🌐 Tran: localize Slashes page descriptions

### DIFF
--- a/src/lib/i18n/de.json
+++ b/src/lib/i18n/de.json
@@ -413,7 +413,19 @@
 		"good_luck": "Viel Glück!",
 		"wheel_label": "Glücksrad",
 		"mute": "Haptik stummschalten",
-		"unmute": "Haptik einschalten"
+		"unmute": "Haptik einschalten",
+		"items": {
+			"about": "mehr über mich",
+			"contact": "wie man mich erreicht",
+			"defaults": "meine Standard-Apps auf iOS und macOS (mehr unter defaults.rknight.me)",
+			"interests": "was mich interessiert",
+			"log": "ein Änderungsprotokoll für diese Webseite",
+			"now": "was ich gerade mache",
+			"slashes": "diese Seite",
+			"uses": "Dinge, die ich benutze",
+			"where": "wo ich die meiste Zeit verbringe",
+			"playlists": "meine Lieblingslieder"
+		}
 	},
 	"concerts": {
 		"title": "Konzerte & Festivals",
@@ -546,7 +558,7 @@
 		"versions": "Versionen",
 		"no_description": "Keine Beschreibung",
 		"view_on_github": "Auf GitHub ansehen"
-  },
+	},
 	"desktop": {
 		"open": "Öffnen",
 		"open_new_tab": "In neuem Tab öffnen",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -413,7 +413,19 @@
 		"good_luck": "Good Luck!",
 		"wheel_label": "Wheel of Fortune",
 		"mute": "Mute haptics",
-		"unmute": "Unmute haptics"
+		"unmute": "Unmute haptics",
+		"items": {
+			"about": "more about me",
+			"contact": "how to reach me",
+			"defaults": "my main apps on iOS and macOS (more at defaults.rknight.me)",
+			"interests": "what I'm interested in",
+			"log": "a changelog for this website",
+			"now": "what i'm doing right now",
+			"slashes": "this page",
+			"uses": "things I use",
+			"where": "where I spend most of my time",
+			"playlists": "my favorite songs"
+		}
 	},
 	"concerts": {
 		"title": "Concerts & Festivals",
@@ -546,7 +558,7 @@
 		"versions": "Versions",
 		"no_description": "No description",
 		"view_on_github": "View on GitHub"
-  },
+	},
 	"desktop": {
 		"open": "Open",
 		"open_new_tab": "Open in New Tab",

--- a/src/routes/slashes/+page.svelte
+++ b/src/routes/slashes/+page.svelte
@@ -19,22 +19,26 @@
 		showSwitch: false
 	});
 
-	const slashes = [
-		{ label: '/about', href: '/about', description: '' },
-		{ label: '/contact', href: '/contact', description: 'how to reach me' },
+	const slashes = $derived([
+		{ label: '/about', href: '/about', description: i18n.t('slashes.items.about') },
+		{ label: '/contact', href: '/contact', description: i18n.t('slashes.items.contact') },
 		{
 			label: '/defaults',
 			href: '/defaults',
-			description: 'my main apps on iOS and macOS (more at defaults.rknight.me)'
+			description: i18n.t('slashes.items.defaults')
 		},
-		{ label: '/interests', href: '/zettelkasten/interests', description: "what I'm interested in" },
-		{ label: '/log', href: '/log', description: 'a changelog for this website' },
-		{ label: '/now', href: '/now', description: "what i'm doing right now" },
-		{ label: '/slashes', href: '/slashes', description: 'this page' },
-		{ label: '/uses', href: '/uses', description: 'things I use' },
-		{ label: '/where', href: '/where', description: 'where I spend most of my time' },
-		{ label: '/playlists', href: '/playlists', description: 'my favorite songs' }
-	];
+		{
+			label: '/interests',
+			href: '/zettelkasten/interests',
+			description: i18n.t('slashes.items.interests')
+		},
+		{ label: '/log', href: '/log', description: i18n.t('slashes.items.log') },
+		{ label: '/now', href: '/now', description: i18n.t('slashes.items.now') },
+		{ label: '/slashes', href: '/slashes', description: i18n.t('slashes.items.slashes') },
+		{ label: '/uses', href: '/uses', description: i18n.t('slashes.items.uses') },
+		{ label: '/where', href: '/where', description: i18n.t('slashes.items.where') },
+		{ label: '/playlists', href: '/playlists', description: i18n.t('slashes.items.playlists') }
+	]);
 
 	let rotation = $state(0);
 	let isSpinning = $state(false);
@@ -48,7 +52,7 @@
 
 	let displayRotation = $derived(isSpinning ? spinTween.current : rotation);
 
-	const segmentAngle = 360 / slashes.length;
+	const segmentAngle = $derived(360 / slashes.length);
 
 	let lastAngle = 0;
 	let lastTime = 0;
@@ -202,7 +206,7 @@
 			<Button
 				onclick={spin}
 				disabled={isSpinning}
-				class="transition-all hover:scale-105 active:scale-95 min-w-28"
+				class="min-w-28 transition-all hover:scale-105 active:scale-95"
 			>
 				{isSpinning ? i18n.t('slashes.good_luck') : i18n.t('slashes.spin')}
 			</Button>


### PR DESCRIPTION
💡 What: Localized item descriptions on the Slashes page.
🎯 Why: The item descriptions were hardcoded in English, making the page inconsistent when switching to German.
🔬 Measurement: Navigate to /slashes and switch between English and German. The descriptions under the selected segment should update accordingly.

---
*PR created automatically by Jules for task [10642183360278263110](https://jules.google.com/task/10642183360278263110) started by @dnnsmnstrr*