### PR TITLE
🌐 Tran: [localize accessibility labels in DraggableWindow]

### DIFF
--- a/.jules/tran.md
+++ b/.jules/tran.md
@@ -65,3 +65,9 @@
 **Learning:** When localizing components that display data categorized by pre-defined keys (like "Spring", "Summer"), reusing existing i18n namespaces (e.g., `playlists.seasons`) ensures that the terminology remains consistent across different parts of the application. This avoids "translation drift" where the same concept is translated differently in separate files.
 
 **Action:** Always search the `en.json` and `de.json` files for existing keys that match the data values before adding new ones. Use dynamic path construction with `i18n.t()` to localize these values reactively.
+
+## 2026-04-03 - [Localizing Accessibility Labels in Interactive Components]
+
+**Learning:** Interactive components like Draggable Windows often contain accessibility labels (aria-label) that remain hardcoded in English, even when the rest of the UI is localized. These labels are crucial for screen reader users and should always be internationalized using the same `i18n.t()` pattern as visible text.
+
+**Action:** Scan for hardcoded `aria-label` attributes in interactive elements (resizers, draggers, buttons) and replace them with localized keys. Use interpolation for dynamic labels (e.g., `desktop.drag_file` with `{name}`).

--- a/src/lib/components/DraggableWindow.svelte
+++ b/src/lib/components/DraggableWindow.svelte
@@ -464,6 +464,7 @@
 				<div class={cn('flex h-full items-center justify-center', className)}>
 					<slot />
 				</div>
+				<!-- Localization: Use i18n for accessibility labels to support multi-language window resizing -->
 				<div
 					class="absolute bottom-0 right-0 hidden h-8 w-8 cursor-nwse-resize select-none md:block"
 					onpointerdown={handleResizePointerDown}
@@ -472,7 +473,7 @@
 					onpointercancel={handleResizePointerUp}
 					role="button"
 					tabindex="-1"
-					aria-label="Resize window"
+					aria-label={i18n.t('window.resize')}
 				></div>
 			</Card.Root>
 		</div>
@@ -494,7 +495,8 @@
 						ondragstart={(e) => e.preventDefault()}
 						role="button"
 						tabindex="-1"
-						aria-label="Drag {fileItem.name || fileItem.id}"
+						/* Localization: Localize aria-label for desktop file interaction */
+						aria-label={i18n.t('desktop.drag_file', { name: fileItem.name || fileItem.id })}
 					>
 						<File
 							name={fileItem.name || fileItem.id}

--- a/src/lib/i18n/de.json
+++ b/src/lib/i18n/de.json
@@ -190,7 +190,8 @@
 		"close": "Fenster schließen",
 		"minimize": "Fenster minimieren",
 		"maximize": "Fenster maximieren",
-		"restore": "Fenster wiederherstellen"
+		"restore": "Fenster wiederherstellen",
+		"resize": "Fenstergröße ändern"
 	},
 	"now": {
 		"title": "Now - Was ich gerade mache",
@@ -554,6 +555,7 @@
 		"rename_prompt": "Neuen Namen eingeben:",
 		"change_icon": "Icon ändern",
 		"delete": "Löschen",
+		"drag_file": "{name} ziehen",
 		"icons": {
 			"folder": "Ordner",
 			"file": "Datei",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -190,7 +190,8 @@
 		"close": "Close window",
 		"minimize": "Minimize window",
 		"maximize": "Maximize window",
-		"restore": "Restore window"
+		"restore": "Restore window",
+		"resize": "Resize window"
 	},
 	"now": {
 		"title": "What I'm doing Now",
@@ -554,6 +555,7 @@
 		"rename_prompt": "Enter new name:",
 		"change_icon": "Change Icon",
 		"delete": "Delete",
+		"drag_file": "Drag {name}",
 		"icons": {
 			"folder": "Folder",
 			"file": "File",


### PR DESCRIPTION
### 💡 What
Localized the hardcoded `aria-label` attributes in the `DraggableWindow.svelte` component. Specifically, the "Resize window" label and the "Drag {name}" label for desktop files are now managed through the i18n service.

### 🎯 Why
Accessibility labels are often overlooked in localization, leaving interactive elements incomprehensible to non-English screen reader users. This change ensures that the desktop environment remains accessible and consistent across supported languages.

### 🔬 Measurement
Verified the change using a Playwright script that checks for the presence of the localized labels in both English and German after a language switch.

- **English:** `Resize window`, `Drag Projects`
- **German:** `Fenstergröße ändern`, `Projects ziehen`

No regressions were found in existing unit tests.

---
*PR created automatically by Jules for task [9408989353643122328](https://jules.google.com/task/9408989353643122328) started by @dnnsmnstrr*