### PR TITLE
🌐 Tran: [consistent locale-aware sorting]

### DIFF
--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -1,3 +1,5 @@
+import { i18n } from '$lib/i18n/i18n.svelte';
+
 export type DataItem = {
 	title?: string;
 	description?: string;
@@ -29,8 +31,8 @@ export function sortData(items: DataItem[], key: keyof DataItem, direction: Sort
 		}
 
 		if (typeof aValue === 'string' && typeof bValue === 'string') {
-			if (direction === 'asc') return aValue.localeCompare(bValue);
-			else return bValue.localeCompare(aValue);
+			if (direction === 'asc') return aValue.localeCompare(bValue, i18n.lang);
+			else return bValue.localeCompare(aValue, i18n.lang);
 		}
 
 		if (typeof aValue === 'number' && typeof bValue === 'number') {
@@ -39,8 +41,8 @@ export function sortData(items: DataItem[], key: keyof DataItem, direction: Sort
 		}
 
 		// fallback to string comparison
-		if (direction === 'asc') return String(aValue).localeCompare(String(bValue));
-		else return String(bValue).localeCompare(String(aValue));
+		if (direction === 'asc') return String(aValue).localeCompare(String(bValue), i18n.lang);
+		else return String(bValue).localeCompare(String(aValue), i18n.lang);
 	});
 	return filteredItems;
 }

--- a/src/routes/concerts/+page.svelte
+++ b/src/routes/concerts/+page.svelte
@@ -60,7 +60,9 @@
 	);
 
 	let festivals = $derived(
-		(data.festivals as Festival[]).sort((a, b) => b.year - a.year || a.name.localeCompare(b.name))
+		(data.festivals as Festival[]).sort(
+			(a, b) => b.year - a.year || a.name.localeCompare(b.name, i18n.lang)
+		)
 	);
 
 	function getMusicBrainzUrl(mbid: string) {

--- a/src/routes/concerts/ConcertStats.svelte
+++ b/src/routes/concerts/ConcertStats.svelte
@@ -48,7 +48,7 @@
 
 		return Object.entries(counts)
 			.map(([name, count]) => ({ name, count }))
-			.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+			.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, i18n.lang));
 	});
 
 	let maxSeen = $derived(Math.max(...artistStats.map((s) => s.count), 1));

--- a/src/routes/playlists/TopArtists.svelte
+++ b/src/routes/playlists/TopArtists.svelte
@@ -48,7 +48,7 @@
         });
         return Object.entries(counts)
             .map(([name, count]) => ({ name, count }))
-            .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+            .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name, i18n.lang));
     });
 
     let maxAppearances = $derived(Math.max(...artistStats.map(s => s.count), 1));


### PR DESCRIPTION
💡 What: Optimized string sorting to be locale-aware by passing `i18n.lang` to `localeCompare`.
🎯 Why: Ensures that alphabetical sorting of artists, festivals, and API data is correct for both English and German users, improving consistency and internationalization.
🔬 Measurement: Verified that all `localeCompare` calls in the modified files now use the reactive `i18n.lang` state.

---
*PR created automatically by Jules for task [14981260033994413360](https://jules.google.com/task/14981260033994413360) started by @dnnsmnstrr*