### PR TITLE
🌐 Tran: localize desktop aria-labels

### DIFF
--- a/src/lib/components/DraggableWindow.svelte
+++ b/src/lib/components/DraggableWindow.svelte
@@ -472,7 +472,8 @@
 					onpointercancel={handleResizePointerUp}
 					role="button"
 					tabindex="-1"
-					aria-label="Resize window"
+					/* Localization optimization: Use localized aria-label for window resize handle */
+					aria-label={i18n.t('desktop.resize_window')}
 				></div>
 			</Card.Root>
 		</div>
@@ -494,7 +495,8 @@
 						ondragstart={(e) => e.preventDefault()}
 						role="button"
 						tabindex="-1"
-						aria-label="Drag {fileItem.name || fileItem.id}"
+						/* Localization optimization: Use localized aria-label for desktop file drag handle */
+						aria-label={i18n.t('desktop.drag_file', { name: fileItem.name || fileItem.id })}
 					>
 						<File
 							name={fileItem.name || fileItem.id}

--- a/src/lib/i18n/de.json
+++ b/src/lib/i18n/de.json
@@ -554,6 +554,8 @@
 		"rename_prompt": "Neuen Namen eingeben:",
 		"change_icon": "Icon ändern",
 		"delete": "Löschen",
+		"resize_window": "Fenstergröße ändern",
+		"drag_file": "{name} ziehen",
 		"icons": {
 			"folder": "Ordner",
 			"file": "Datei",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -554,6 +554,8 @@
 		"rename_prompt": "Enter new name:",
 		"change_icon": "Change Icon",
 		"delete": "Delete",
+		"resize_window": "Resize window",
+		"drag_file": "Drag {name}",
 		"icons": {
 			"folder": "Folder",
 			"file": "File",


### PR DESCRIPTION
💡 What: Localized hardcoded `aria-label` strings for the window resize handle and desktop file drag handles in `DraggableWindow.svelte`.

🎯 Why: Improves accessibility and consistency for non-English users by ensuring screen readers announce these interactive elements in the active language.

🔬 Measurement: Verified using Playwright by switching locales and asserting that `aria-label` attributes match the translations in `en.json` and `de.json`. Screenshots for both English and German were generated and inspected.

---
*PR created automatically by Jules for task [17953145662111735404](https://jules.google.com/task/17953145662111735404) started by @dnnsmnstrr*