### PR TITLE
🌐 Tran: [localize slashes item descriptions]

### DIFF
--- a/src/lib/i18n/de.json
+++ b/src/lib/i18n/de.json
@@ -413,7 +413,19 @@
 		"good_luck": "Viel Glück!",
 		"wheel_label": "Glücksrad",
 		"mute": "Haptik stummschalten",
-		"unmute": "Haptik einschalten"
+		"unmute": "Haptik einschalten",
+		"items": {
+			"about": "",
+			"contact": "wie man mich erreicht",
+			"defaults": "meine Standard-Apps auf iOS und macOS (mehr auf defaults.rknight.me)",
+			"interests": "was mich interessiert",
+			"log": "ein Änderungsprotokoll für diese Webseite",
+			"now": "was ich gerade so mache",
+			"slashes": "diese Seite",
+			"uses": "Dinge, die ich benutze",
+			"where": "wo ich die meiste Zeit verbringe",
+			"playlists": "meine Lieblingslieder"
+		}
 	},
 	"concerts": {
 		"title": "Konzerte & Festivals",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -413,7 +413,19 @@
 		"good_luck": "Good Luck!",
 		"wheel_label": "Wheel of Fortune",
 		"mute": "Mute haptics",
-		"unmute": "Unmute haptics"
+		"unmute": "Unmute haptics",
+		"items": {
+			"about": "",
+			"contact": "how to reach me",
+			"defaults": "my main apps on iOS and macOS (more at defaults.rknight.me)",
+			"interests": "what I'm interested in",
+			"log": "a changelog for this website",
+			"now": "what i'm doing right now",
+			"slashes": "this page",
+			"uses": "things I use",
+			"where": "where I spend most of my time",
+			"playlists": "my favorite songs"
+		}
 	},
 	"concerts": {
 		"title": "Concerts & Festivals",

--- a/src/routes/slashes/+page.svelte
+++ b/src/routes/slashes/+page.svelte
@@ -19,22 +19,27 @@
 		showSwitch: false
 	});
 
-	const slashes = [
-		{ label: '/about', href: '/about', description: '' },
-		{ label: '/contact', href: '/contact', description: 'how to reach me' },
+	// Localization: Define slash pages reactively to support language switching
+	const slashes = $derived([
+		{ label: '/about', href: '/about', description: i18n.t('slashes.items.about') },
+		{ label: '/contact', href: '/contact', description: i18n.t('slashes.items.contact') },
 		{
 			label: '/defaults',
 			href: '/defaults',
-			description: 'my main apps on iOS and macOS (more at defaults.rknight.me)'
+			description: i18n.t('slashes.items.defaults')
 		},
-		{ label: '/interests', href: '/zettelkasten/interests', description: "what I'm interested in" },
-		{ label: '/log', href: '/log', description: 'a changelog for this website' },
-		{ label: '/now', href: '/now', description: "what i'm doing right now" },
-		{ label: '/slashes', href: '/slashes', description: 'this page' },
-		{ label: '/uses', href: '/uses', description: 'things I use' },
-		{ label: '/where', href: '/where', description: 'where I spend most of my time' },
-		{ label: '/playlists', href: '/playlists', description: 'my favorite songs' }
-	];
+		{
+			label: '/interests',
+			href: '/zettelkasten/interests',
+			description: i18n.t('slashes.items.interests')
+		},
+		{ label: '/log', href: '/log', description: i18n.t('slashes.items.log') },
+		{ label: '/now', href: '/now', description: i18n.t('slashes.items.now') },
+		{ label: '/slashes', href: '/slashes', description: i18n.t('slashes.items.slashes') },
+		{ label: '/uses', href: '/uses', description: i18n.t('slashes.items.uses') },
+		{ label: '/where', href: '/where', description: i18n.t('slashes.items.where') },
+		{ label: '/playlists', href: '/playlists', description: i18n.t('slashes.items.playlists') }
+	]);
 
 	let rotation = $state(0);
 	let isSpinning = $state(false);
@@ -48,7 +53,8 @@
 
 	let displayRotation = $derived(isSpinning ? spinTween.current : rotation);
 
-	const segmentAngle = 360 / slashes.length;
+	// Localization: Ensure the segment angle is recalculated reactively
+	const segmentAngle = $derived(360 / slashes.length);
 
 	let lastAngle = 0;
 	let lastTime = 0;


### PR DESCRIPTION
This PR localizes the descriptions of the items on the Slashes page wheel. 

The descriptions were previously hardcoded in the `slashes` array within `src/routes/slashes/+page.svelte`. I've moved these strings to `en.json` and `de.json` under the `slashes.items` namespace. 

To ensure the UI updates reactively when the language is changed, I converted the `slashes` array and the `segmentAngle` variable into Svelte 5 `$derived` runes.

### Changes:
- Added `slashes.items` to `src/lib/i18n/en.json` and `src/lib/i18n/de.json`.
- Modified `src/routes/slashes/+page.svelte` to use reactive `$derived` runes for the `slashes` list and `segmentAngle`.
- Updated descriptions to use `i18n.t()`.

Verified visually in both English and German using Playwright.

---
*PR created automatically by Jules for task [11230714434014406238](https://jules.google.com/task/11230714434014406238) started by @dnnsmnstrr*