### PR TITLE
recenter window on fullscreen toggle

### DIFF
--- a/src/lib/components/DraggableWindow.svelte
+++ b/src/lib/components/DraggableWindow.svelte
@@ -102,6 +102,14 @@
 		}
 	}
 
+	function recenter() {
+		DraggableWidth = defaultWidth;
+		DraggableHeight = minHeight;
+		DraggableX = width / 2 - DraggableWidth / 2;
+		DraggableY = height / 3 - DraggableHeight / 2;
+		isMaximized = false;
+	}
+
 	// DVD Bounce animation
 	let bounceAnimationId: number | null = null;
 	let velocityX = 2;
@@ -263,6 +271,18 @@
 				cancelAnimationFrame(bounceAnimationId);
 				bounceAnimationId = null;
 			}
+		};
+	});
+
+	$effect(() => {
+		const handleFullscreenChange = () => {
+			// Wait for the viewport dimensions to update
+			setTimeout(recenter, 100);
+		};
+
+		document.addEventListener('fullscreenchange', handleFullscreenChange);
+		return () => {
+			document.removeEventListener('fullscreenchange', handleFullscreenChange);
 		};
 	});
 
@@ -451,12 +471,7 @@
 					onpointermove={handleWindowPointerMove}
 					onpointerup={handleWindowPointerUp}
 					onpointercancel={handleWindowPointerUp}
-					ondblclick={() => {
-						DraggableWidth = defaultWidth;
-						DraggableHeight = minHeight;
-						DraggableX = width / 2 - DraggableWidth / 2;
-						DraggableY = height / 3 - DraggableHeight / 2;
-					}}
+					ondblclick={recenter}
 				>
 					<WindowButtons {isMaximized} onMaximize={toggleMaximize} />
 				</div>


### PR DESCRIPTION
This change ensures that draggable windows are automatically centered and reset to their default size whenever the fullscreen mode is toggled. This improves the user experience by keeping the window in focus and preventing it from being misplaced after layout changes.

Specifically:
- Extracted window centering logic into a reusable `recenter` function in `DraggableWindow.svelte`.
- Added an `$effect` to listen for the `fullscreenchange` event, which triggers `recenter` after a short delay (allowing the viewport to update).
- Cleaned up the `ondblclick` handler by calling the new `recenter` function.
- Verified the fix with a Playwright script that simulates viewport changes and dispatches the `fullscreenchange` event.

---
*PR created automatically by Jules for task [124067065456024686](https://jules.google.com/task/124067065456024686) started by @dnnsmnstrr*