### PR TITLE
Configurable screensaver timeout

### DIFF
--- a/src/lib/components/DraggableWindow.svelte
+++ b/src/lib/components/DraggableWindow.svelte
@@ -29,8 +29,7 @@
 		Image as ImageIcon
 	} from 'lucide-svelte';
 	import File from './File.svelte';
-	import { debugLog, dvdBounceEnabled } from '$lib/stores/app';
-	import { INACTIVITY_TIMEOUT } from '$lib/config';
+	import { debugLog, dvdBounceEnabled, inactivityTimeout } from '$lib/stores/app';
 	import { i18n } from '$lib/i18n/i18n.svelte';
 
 
@@ -298,7 +297,7 @@
 			if (!$dvdBounceActive) {
 				dvdBounceActive.set(true);
 			}
-		}, INACTIVITY_TIMEOUT);
+		}, $inactivityTimeout * 1000);
 	}
 
 	// Initialize inactivity timer on mount and add global event listeners

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -123,7 +123,6 @@ export const breakpoints = {
 	xl: 1920
 };
 
-export const INACTIVITY_TIMEOUT = 1 * 30 * 1000; // 1 minute in milliseconds
 
 export const backgroundTextures = [
 	{

--- a/src/lib/i18n/de.json
+++ b/src/lib/i18n/de.json
@@ -113,6 +113,7 @@
 		"debug_description": "Führt zu detaillierterem Output in der Konsole.",
 		"dvd_bounce": "Bildschirmschoner",
 		"enable_dvd_bounce": "DVD Bounce",
+		"inactivity_timeout": "Inaktivitäts-Timeout",
 		"actions": "Aktionen",
 		"reset_desktop": "Desktop zurücksetzen",
 		"reset_success": "Desktop zurückgesetzt",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -113,6 +113,7 @@
 		"debug_description": "This will cause more verbose logging in the console.",
 		"dvd_bounce": "Screensaver",
 		"enable_dvd_bounce": "DVD Bounce",
+		"inactivity_timeout": "Inactivity Timeout",
 		"actions": "Actions",
 		"reset_desktop": "Reset Desktop",
 		"reset_success": "Desktop files reset to default positions",

--- a/src/lib/stores/app.ts
+++ b/src/lib/stores/app.ts
@@ -65,6 +65,15 @@ dvdBounceEnabled.subscribe((value) => {
 	}
 });
 
+export const DEFAULT_INACTIVITY_TIMEOUT = 30;
+const storedInactivityTimeout = browser ? window?.localStorage?.inactivityTimeout : String(DEFAULT_INACTIVITY_TIMEOUT);
+export const inactivityTimeout = writable<number>(Number(storedInactivityTimeout) || DEFAULT_INACTIVITY_TIMEOUT);
+inactivityTimeout.subscribe((value) => {
+	if (browser && window?.localStorage) {
+		window.localStorage.inactivityTimeout = String(value);
+	}
+});
+
 // background texture
 const storedBackgroundTexture = browser ? window?.localStorage?.backgroundTexture : 'dots';
 export const backgroundTexture = writable<string>(storedBackgroundTexture || 'dots');

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -13,7 +13,7 @@
 	import { zodClient } from 'sveltekit-superforms/adapters';
 	import { settingsSchema } from './schema';
 	import { get } from 'svelte/store';
-	import { backgroundTexture, backgroundSize, backgroundSpacing } from '$lib/stores/app';
+	import { backgroundTexture, backgroundSize, backgroundSpacing, inactivityTimeout } from '$lib/stores/app';
 	import type { SuperValidated, Infer } from 'sveltekit-superforms';
 	import type { SettingsSchema } from './schema';
 	import Separator from '$lib/components/ui/separator/separator.svelte';
@@ -26,6 +26,7 @@
 			mode: 'system',
 			language: i18n.lang,
 			dvdBounceEnabled: false,
+			inactivityTimeout: get(inactivityTimeout),
 			backgroundTexture: get(backgroundTexture),
 			backgroundSize: get(backgroundSize),
 			backgroundSpacing: get(backgroundSpacing)

--- a/src/routes/settings/AppearanceSettings.svelte
+++ b/src/routes/settings/AppearanceSettings.svelte
@@ -113,12 +113,12 @@
 										class="w-20"
 										bind:value={$inactivityTimeout}
 										{...props}
-										min="1"
+										min="30"
 										max="3600"
-										step="1"
+										step="30"
 									/>
 									<span class="text-sm text-muted-foreground"
-										>{i18n.t('duration.s')}</span
+										>{$inactivityTimeout >= 60 ? formatDuration($inactivityTimeout * 1000) : i18n.t('duration.s')}</span
 									>
 								</div>
 							{/snippet}

--- a/src/routes/settings/AppearanceSettings.svelte
+++ b/src/routes/settings/AppearanceSettings.svelte
@@ -5,6 +5,7 @@
 	import { mode, setMode, resetMode } from 'mode-watcher';
 	import {
 		dvdBounceEnabled,
+		inactivityTimeout,
 		backgroundTexture,
 		backgroundSize,
 		backgroundSpacing,
@@ -19,7 +20,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { cn } from '$lib/utils';
 	import { i18n } from '$lib/i18n/i18n.svelte';
-	import { INACTIVITY_TIMEOUT, backgroundTextures } from '$lib/config';
+	import { backgroundTextures } from '$lib/config';
 	import { Input } from '$lib/components/ui/input';
 	import { formatDuration } from '$lib/utils/helper';
 	import type { SettingsSchema } from './schema';
@@ -76,31 +77,56 @@
 			</Form.Control>
 		</Form.Field>
 	
-		<Form.Field {form} name="dvdBounceEnabled" class="flex flex-col justify-between gap-2">
-			<div class="flex flex-col space-y-2">
-				<h2>{i18n.t('settings.dvd_bounce')}</h2>
-				<div class="flex items-center space-x-3 space-y-0">
-					<Form.Control>
-						{#snippet children({ props })}
-							<Checkbox
-								{...props}
-								checked={$dvdBounceEnabled}
-								onCheckedChange={(value) => ($dvdBounceEnabled = !!value)}
-								id="dvd-bounce-checkbox"
-							/>
-							<Form.Label
-								for="dvd-bounce-checkbox"
-								class="font-normal"
-								title={formatDuration(INACTIVITY_TIMEOUT)}
-								onclick={() => ($dvdBounceEnabled = !$dvdBounceEnabled)}
-							>
-								{i18n.t('settings.enable_dvd_bounce')}
-							</Form.Label>
-						{/snippet}
-					</Form.Control>
-				</div>
+		<div class="flex flex-col gap-2">
+			<h2>{i18n.t('settings.dvd_bounce')}</h2>
+			<div class="flex flex-row items-end gap-4">
+				<Form.Field {form} name="dvdBounceEnabled" class="flex flex-col justify-between">
+					<div class="flex items-center space-x-3 space-y-0 h-10">
+						<Form.Control>
+							{#snippet children({ props })}
+								<Checkbox
+									{...props}
+									checked={$dvdBounceEnabled}
+									onCheckedChange={(value) => ($dvdBounceEnabled = !!value)}
+									id="dvd-bounce-checkbox"
+								/>
+								<Form.Label
+									for="dvd-bounce-checkbox"
+									class="font-normal"
+									title={formatDuration($inactivityTimeout * 1000)}
+									onclick={() => ($dvdBounceEnabled = !$dvdBounceEnabled)}
+								>
+									{i18n.t('settings.enable_dvd_bounce')}
+								</Form.Label>
+							{/snippet}
+						</Form.Control>
+					</div>
+				</Form.Field>
+
+				{#if $dvdBounceEnabled}
+					<Form.Field {form} name="inactivityTimeout" class="flex flex-col justify-between">
+						<Form.Control>
+							{#snippet children({ props })}
+								<div class="flex items-center gap-2">
+									<Input
+										type="number"
+										class="w-20"
+										bind:value={$inactivityTimeout}
+										{...props}
+										min="1"
+										max="3600"
+										step="1"
+									/>
+									<span class="text-sm text-muted-foreground"
+										>{i18n.t('duration.s')}</span
+									>
+								</div>
+							{/snippet}
+						</Form.Control>
+					</Form.Field>
+				{/if}
 			</div>
-		</Form.Field>
+		</div>
 	</div>
 
 	<div class="grid grid-cols-2 gap-2 md:grid-cols-3 pt-4">

--- a/src/routes/settings/schema.ts
+++ b/src/routes/settings/schema.ts
@@ -4,6 +4,7 @@ export const settingsSchema = z.object({
     mode: z.string().default('system'),
     language: z.string().default('en'),
     dvdBounceEnabled: z.boolean().default(false),
+    inactivityTimeout: z.number().default(30),
     backgroundTexture: z.string().default('dots'),
     backgroundSize: z.number().default(1),
     backgroundSpacing: z.number().default(16)


### PR DESCRIPTION
This change introduces a new setting in the Appearance tab that allows users to configure the duration of inactivity (in seconds) before the screensaver (DVD bounce) activates. The setting is persisted in localStorage and the default is set to 30 seconds.

---
*PR created automatically by Jules for task [4181745575168127698](https://jules.google.com/task/4181745575168127698) started by @dnnsmnstrr*