### PR TITLE
Implement server-side caching for gist data

### DIFF
--- a/src/lib/server/cache.ts
+++ b/src/lib/server/cache.ts
@@ -1,0 +1,35 @@
+type CacheEntry<T> = {
+	value: T;
+	expiry: number;
+};
+
+class MemoryCache {
+	private cache: Map<string, CacheEntry<any>> = new Map();
+
+	set<T>(key: string, value: T, ttlSeconds: number): void {
+		const expiry = Date.now() + ttlSeconds * 1000;
+		this.cache.set(key, { value, expiry });
+	}
+
+	get<T>(key: string): T | null {
+		const entry = this.cache.get(key);
+		if (!entry) return null;
+
+		if (Date.now() > entry.expiry) {
+			this.cache.delete(key);
+			return null;
+		}
+
+		return entry.value as T;
+	}
+
+	delete(key: string): void {
+		this.cache.delete(key);
+	}
+
+	clear(): void {
+		this.cache.clear();
+	}
+}
+
+export const gistCache = new MemoryCache();

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -248,6 +248,17 @@
 
 			gistInfo = updatedData;
 
+			// Invalidate server-side cache
+			const gistName =
+				selectedGist === ''
+					? null
+					: Object.keys(gists).find((key) => gists[key as keyof typeof gists].id === selectedGist);
+			if (gistName) {
+				fetch(`/api/gists/${gistName}?refresh=true`).catch((err) =>
+					console.error('Failed to refresh cache:', err)
+				);
+			}
+
 			toast.success('Gist saved successfully!');
 		} catch (error) {
 			console.error('Error saving gist:', error);

--- a/src/routes/api/gists/[name]/+server.ts
+++ b/src/routes/api/gists/[name]/+server.ts
@@ -1,12 +1,25 @@
 import { gists } from '$lib/config';
+import { gistCache } from '$lib/server/cache';
 import { json } from '@sveltejs/kit';
+
+const CACHE_TTL = 15 * 60; // 15 minutes in seconds
 
 export async function GET({ params, url }) {
 	const { name } = params;
-	const gist = gists[name];
+	const refresh = url.searchParams.get('refresh') === 'true';
+
+	const gist = gists[name as keyof typeof gists];
 	if (!gist) {
 		return json({ error: 'Gist not found for name: ' + name }, { status: 404 });
 	}
+
+	if (!refresh) {
+		const cachedData = gistCache.get(name);
+		if (cachedData) {
+			return json(cachedData);
+		}
+	}
+
 	const gistApiUrl = `https://api.github.com/gists/${gist.id}`;
 
 	try {
@@ -25,7 +38,12 @@ export async function GET({ params, url }) {
 			changes: item.change_status?.total
 		}));
 
-		return json({ ...gistData, updatedAt, gistUrl: apiData.html_url, versions });
+		const responseData = { ...gistData, updatedAt, gistUrl: apiData.html_url, versions };
+
+		// Update cache
+		gistCache.set(name, responseData, CACHE_TTL);
+
+		return json(responseData);
 	} catch (error) {
 		return json({ error }, { status: 500 });
 	}


### PR DESCRIPTION
Implemented a server-side in-memory cache for GitHub Gist data to improve performance and reduce API rate limit consumption. The cache has a 15-minute TTL and is automatically invalidated when updates are made via the admin panel.

---
*PR created automatically by Jules for task [91274870331228922](https://jules.google.com/task/91274870331228922) started by @dnnsmnstrr*