### PR TITLE
Playlist Covers Standalone Page

### DIFF
--- a/src/lib/components/NowPlaying.svelte
+++ b/src/lib/components/NowPlaying.svelte
@@ -7,16 +7,7 @@
 	import { cn } from '$lib/utils';
 	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { i18n } from '$lib/i18n/i18n.svelte';
-
-	interface PlaylistItem {
-		title: string;
-		type: 'season' | 'aggregated' | 'theme' | 'hidden';
-		season?: 'winter' | 'spring' | 'summer' | 'autumn';
-		year?: number;
-		uri: string;
-		emoji?: string;
-		imageUrl?: string;
-	}
+	import type { PlaylistItem } from '$lib/types';
 
 	let { side = 'right', expanded = $bindable(false) } = $props<{
 		side?: 'left' | 'right';

--- a/src/lib/components/PlaylistScreensaver.svelte
+++ b/src/lib/components/PlaylistScreensaver.svelte
@@ -2,7 +2,10 @@
 	import { onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { screensaverActive } from '$lib/stores/desktop';
-	import type { PlaylistItem } from '../../routes/playlists/+page.svelte';
+	import type { PlaylistItem } from '$lib/types';
+	import { SPOTIFY_PLAYLIST_LINK } from '$lib/config';
+
+	let { standalone = false } = $props<{ standalone?: boolean }>();
 
 	let playlists = $state<PlaylistItem[]>([]);
 	let visibleGrid = $state<PlaylistItem[]>([]);
@@ -136,6 +139,7 @@
 	});
 
 	function handleActivity() {
+		if (standalone) return;
 		$screensaverActive = false;
 	}
 </script>
@@ -149,7 +153,7 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-	class="fixed inset-0 z-[100] overflow-hidden bg-black"
+	class={standalone ? 'h-full w-full overflow-hidden bg-black' : 'fixed inset-0 z-[100] overflow-hidden bg-black'}
 	transition:fade={{ duration: 1000 }}
 	onclick={handleActivity}
 	onkeydown={handleActivity}
@@ -163,12 +167,28 @@
 						in:rotateIn={{ duration: 700 }}
 						out:rotateOut={{ duration: 700 }}
 					>
-						<img
-							src={playlist.imageUrl || `https://i.scdn.co/image/${playlist.imageId}`}
-							alt=""
-							class="h-full w-full object-cover [backface-visibility:hidden]"
-							onerror={() => flipCover(i)}
-						/>
+						{#if standalone}
+							<a
+								href={playlist.url || SPOTIFY_PLAYLIST_LINK + playlist.uri}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="block h-full w-full"
+							>
+								<img
+									src={playlist.imageUrl || `https://i.scdn.co/image/${playlist.imageId}`}
+									alt={playlist.title}
+									class="h-full w-full object-cover [backface-visibility:hidden]"
+									onerror={() => flipCover(i)}
+								/>
+							</a>
+						{:else}
+							<img
+								src={playlist.imageUrl || `https://i.scdn.co/image/${playlist.imageId}`}
+								alt=""
+								class="h-full w-full object-cover [backface-visibility:hidden]"
+								onerror={() => flipCover(i)}
+							/>
+						{/if}
 					</div>
 				{/key}
 			</div>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,6 +10,7 @@ export const NTFY_URL = `https://ntfy.sh/${NTFY_TOPIC}`;
 export const EMAIL_PROVIDER = 'gmail';
 export const CURRENT_DOMAIN = 'muensterer.tech';
 export const API_URL = 'https://dnnsmnstrr.vercel.app';
+export const SPOTIFY_PLAYLIST_LINK = 'https://open.spotify.com/playlist/';
 
 // Username variations
 export const NAME_ABBREVIATION = FIRST_NAME.slice(0, 1) + LAST_NAME.slice(0, 1);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,3 +20,19 @@ export type Event = {
 	/** A URL for more information about the event, must use HTTPS. */
 	url?: string; // Optional, as it's not in the required properties
 };
+
+export interface PlaylistItem {
+	title: string;
+	type: 'season' | 'aggregated' | 'theme' | 'hidden';
+	season?: 'winter' | 'spring' | 'summer' | 'autumn';
+	year?: number;
+	uri: string;
+	url?: string;
+	emoji?: string;
+	description?: string;
+	tags?: string[];
+	gif?: string;
+	imageId?: string;
+	imageUrl?: string;
+	isHovered?: boolean;
+}

--- a/src/routes/playlists/+page.svelte
+++ b/src/routes/playlists/+page.svelte
@@ -1,23 +1,10 @@
 <script module lang="ts">
-	export interface PlaylistItem {
-		title: string;
-		type: 'season' | 'aggregated' | 'theme';
-		season?: 'winter' | 'spring' | 'summer' | 'autumn';
-		year?: number;
-		uri: string;
-		url?: string;
-		emoji?: string;
-		description?: string;
-		tags?: string[];
-		gif?: string;
-		imageId?: string;
-		imageUrl?: string;
-		isHovered?: boolean;
-	}
-	export const SPOTIFY_PLAYLIST_LINK = 'https://open.spotify.com/playlist/';
+	import type { PlaylistItem } from '$lib/types';
+	export { type PlaylistItem };
 </script>
 
 <script lang="ts">
+	import { SPOTIFY_PLAYLIST_LINK } from '$lib/config';
 	import { Heading } from '$lib/components/typography';
 	import Link from '$lib/components/typography/Link.svelte';
 	import Button from '$lib/components/ui/button/button.svelte';

--- a/src/routes/playlists/PlaylistCard.svelte
+++ b/src/routes/playlists/PlaylistCard.svelte
@@ -4,7 +4,8 @@
 	import * as Card from '$lib/components/ui/card';
 	import { breakpoints } from '$lib/config';
 	import { Info } from 'lucide-svelte';
-	import { SPOTIFY_PLAYLIST_LINK, type PlaylistItem } from './+page.svelte';
+	import { SPOTIFY_PLAYLIST_LINK } from '$lib/config';
+	import type { PlaylistItem } from '$lib/types';
 	import { i18n } from '$lib/i18n/i18n.svelte';
 
 	interface Props {

--- a/src/routes/playlists/covers/+page.svelte
+++ b/src/routes/playlists/covers/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import PlaylistScreensaver from '$lib/components/PlaylistScreensaver.svelte';
+</script>
+
+<svelte:head>
+	<title>Playlist Covers</title>
+</svelte:head>
+
+<div class="fixed inset-0 z-40 h-screen w-screen overflow-hidden bg-black">
+	<PlaylistScreensaver standalone={true} />
+</div>


### PR DESCRIPTION
This change implements a standalone version of the playlist covers screensaver as requested. The new page at `/playlists/covers` provides a full-screen, interactive grid of playlist covers that link directly to Spotify or Apple Music. It stays active even with user input, unlike the idle screensaver version. The implementation includes significant refactoring to centralize types and constants, improving code maintainability.

---
*PR created automatically by Jules for task [10149047751572351570](https://jules.google.com/task/10149047751572351570) started by @dnnsmnstrr*