### PR TITLE
Fix ServiceWorker interception error for API requests

### DIFF
--- a/src/routes/api/[slug]/+server.ts
+++ b/src/routes/api/[slug]/+server.ts
@@ -11,7 +11,7 @@ const dataMap: Record<string, any> = {
 };
 const DEFAULT_LIMIT = 50;
 
-export async function GET({ params, url }) {
+export async function GET({ params, url, fetch }) {
 	const { slug } = params;
 
 	if (!dataMap[slug] && (!gists || !gists[slug as keyof typeof gists])) {
@@ -20,8 +20,7 @@ export async function GET({ params, url }) {
 
 	if (!dataMap[slug]) {
 		// fall back to gists
-		const gistUrl = new URL(`/api/gists/${slug}${url.search}`, url.origin);
-		const gistResponse = await fetch(gistUrl);
+		const gistResponse = await fetch(`/api/gists/${slug}${url.search}`);
 
 		if (!gistResponse.ok) {
 			throw error(gistResponse.status, `No static data or gist found for slug: ${slug}`);

--- a/src/routes/api/gists/[name]/+server.ts
+++ b/src/routes/api/gists/[name]/+server.ts
@@ -44,7 +44,7 @@ export async function GET({ params, url }) {
 		gistCache.set(name, responseData, CACHE_TTL);
 
 		return json(responseData);
-	} catch (error) {
-		return json({ error }, { status: 500 });
+	} catch (err: any) {
+		return json({ error: err.message || err }, { status: 500 });
 	}
 }

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -7,9 +7,22 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
+	const url = new URL(event.request.url);
+
+	// Skip interception for API calls or other origins
+	if (url.pathname.startsWith('/api/') || url.origin !== self.location.origin) {
+		return;
+	}
+
 	event.respondWith(
-		caches.match(event.request).then((response) => {
-			return response || fetch(event.request);
-		})
+		caches
+			.match(event.request)
+			.then((response) => {
+				return response || fetch(event.request);
+			})
+			.catch(() => {
+				// Fallback to network if cache match fails or network fetch fails
+				return fetch(event.request);
+			})
 	);
 });


### PR DESCRIPTION
Fixed an issue where the Service Worker was intercepting and causing errors on API requests (specifically /api/events).

Summary of changes:
- Modified `static/service-worker.js` to exclude `/api/` paths and cross-origin requests from fetch interception.
- Refactored `src/routes/api/[slug]/+server.ts` to use the SvelteKit-provided `fetch` function and relative URLs for internal Gist data retrieval, ensuring better performance and reliability.
- Enhanced error handling in `src/routes/api/gists/[name]/+server.ts` to return more descriptive error messages in JSON responses.
- Verified changes by running `pnpm run test:unit` and `pnpm run check`.

---
*PR created automatically by Jules for task [15818433449182236372](https://jules.google.com/task/15818433449182236372) started by @dnnsmnstrr*