### PR TITLE
Track and suggest frequent commands in palette

### DIFF
--- a/src/lib/i18n/de.json
+++ b/src/lib/i18n/de.json
@@ -116,6 +116,7 @@
 		"screensaver_dvd": "DVD Bounce",
 		"screensaver_playlists": "Playlist Cover",
 		"inactivity_timeout": "Inaktivitäts-Timeout",
+		"suggestions_limit": "Limit für Befehlsvorschläge",
 		"actions": "Aktionen",
 		"reset_desktop": "Desktop zurücksetzen",
 		"reset_success": "Desktop zurückgesetzt",
@@ -125,6 +126,7 @@
 		"texture": "Hintergrundstruktur",
 		"texture_size": "Größe",
 		"texture_spacing": "Abstand",
+		"none": "Keine",
 		"dots": "Punkte",
 		"offset-dots": "Versetzte Punkte",
 		"grid": "Gitter",
@@ -149,6 +151,7 @@
 	"command": {
 		"placeholder": "Befehl eingeben oder suchen...",
 		"no_results": "Keine Ergebnisse gefunden.",
+		"suggestions": "Vorschläge",
 		"navigation": "Navigation",
 		"links": "Links",
 		"system": "System",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -114,6 +114,7 @@
 		"screensaver_dvd": "DVD Bounce",
 		"screensaver_playlists": "Playlist Covers",
 		"inactivity_timeout": "Inactivity Timeout",
+		"suggestions_limit": "Command Suggestions Limit",
 		"actions": "Actions",
 		"reset_desktop": "Reset Desktop",
 		"reset_success": "Desktop files reset to default positions",
@@ -123,6 +124,7 @@
 		"texture": "Background Texture",
 		"texture_size": "Texture Size",
 		"texture_spacing": "Texture Spacing",
+		"none": "None",
 		"dots": "Dots",
 		"offset-dots": "Offset Dots",
 		"grid": "Grid",
@@ -147,6 +149,7 @@
 	"command": {
 		"placeholder": "Type a command or search...",
 		"no_results": "No results found.",
+		"suggestions": "Suggestions",
 		"navigation": "Navigation",
 		"links": "Links",
 		"system": "System",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -130,7 +130,6 @@
 		"grid": "Grid",
 		"diagonal": "Diagonal",
 		"wave": "Wave",
-		"none": "None",
 		"themes": {
 			"zinc": "Zinc",
 			"slate": "Slate",

--- a/src/lib/stores/app.ts
+++ b/src/lib/stores/app.ts
@@ -117,3 +117,45 @@ backgroundSpacing.subscribe((value) => {
 		window.localStorage.backgroundSpacing = String(value);
 	}
 });
+
+// command suggestions
+export interface CommandStat {
+	count: number;
+	lastUsed: number;
+}
+
+const storedCommandStats = browser ? window?.localStorage?.commandStats : '{}';
+export const commandStats = writable<Record<string, CommandStat>>(
+	JSON.parse(storedCommandStats || '{}')
+);
+commandStats.subscribe((value) => {
+	if (browser && window?.localStorage) {
+		window.localStorage.commandStats = JSON.stringify(value);
+	}
+});
+
+export function trackCommand(id: string) {
+	commandStats.update((stats) => {
+		const stat = stats[id] || { count: 0, lastUsed: 0 };
+		return {
+			...stats,
+			[id]: {
+				count: stat.count + 1,
+				lastUsed: Date.now()
+			}
+		};
+	});
+}
+
+export const DEFAULT_SUGGESTIONS_LIMIT = 5;
+const storedSuggestionsLimit = browser
+	? window?.localStorage?.suggestionsLimit
+	: String(DEFAULT_SUGGESTIONS_LIMIT);
+export const suggestionsLimit = writable<number>(
+	Number(storedSuggestionsLimit) || DEFAULT_SUGGESTIONS_LIMIT
+);
+suggestionsLimit.subscribe((value) => {
+	if (browser && window?.localStorage) {
+		window.localStorage.suggestionsLimit = String(value);
+	}
+});

--- a/src/lib/stores/desktop.ts
+++ b/src/lib/stores/desktop.ts
@@ -169,6 +169,8 @@ export function resetDesktopFiles() {
 	if (browser && window?.localStorage) {
 		delete window.localStorage.desktopFiles;
 		delete window.localStorage.onboardingComplete;
+		delete window.localStorage.screensaver;
+		delete window.localStorage.commandStats;
 	}
 	if (defaultFiles) {
 		// Reset to default files with new positions

--- a/src/routes/Command.svelte
+++ b/src/routes/Command.svelte
@@ -1,5 +1,6 @@
 <script module lang="ts">
 	type CommandData = {
+		id?: string;
 		name: string;
 		keywords?: string[];
 		value?: string;
@@ -46,7 +47,16 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { mode, toggleMode } from 'mode-watcher';
 	import { onMount } from 'svelte';
-	import { isCommandActive, debug, debugLog, showHelp, screensaver } from '$lib/stores/app';
+	import {
+		isCommandActive,
+		debug,
+		debugLog,
+		showHelp,
+		screensaver,
+		trackCommand,
+		commandStats,
+		suggestionsLimit
+	} from '$lib/stores/app';
 	import { Tween } from 'svelte/motion';
 	import { cubicInOut } from 'svelte/easing';
 	import { goto } from '$app/navigation';
@@ -326,11 +336,14 @@
 		loadingProgress.set(loading ? 100 : 0);
 	});
 
-	const enrichLink = (link: CommandData): CommandData => {
+	const enrichLink = (link: CommandData, translationKey?: string): CommandData => {
 		let href = link.href || '';
 		if (!link.href && !link.action) {
 			href = '/' + link.name.toLowerCase();
 		}
+
+		const id = link.id || href || translationKey || link.name;
+
 		const action =
 			link.action ||
 			function () {
@@ -344,12 +357,19 @@
 					window.open(href);
 				}
 			};
+
+		const wrappedAction = () => {
+			trackCommand(id);
+			action();
+		};
+
 		let value = link.value || link.name;
 		return {
 			...link,
+			id,
 			keywords: link.keywords || link.name.toLowerCase().split(' '),
 			href,
-			action,
+			action: wrappedAction,
 			value
 		};
 	};
@@ -362,7 +382,7 @@
 		{ name: 'LinkedIn', keywords: ['work', 'professional'], icon: Linkedin, href: links.linkedin },
 		{ name: 'Twitter / 𝕏', keywords: ['X'], icon: Twitter, href: links.x },
 		{ name: 'CV', keywords: ['resume', 'curriculum vitae'], icon: ScrollText, href: links.cv }
-	].map(enrichLink);
+	].map((link) => enrichLink(link));
 
 	function toggleDebug() {
 		$debug = !$debug;
@@ -386,177 +406,262 @@
 
 	let currentGroup = $state<string | null>(null);
 
-	let commandConfig = $derived({
-		navigation: [
-			{ name: i18n.t('common.home'), icon: Home, href: '/' },
-			{ name: i18n.t('common.about'), icon: User, href: '/about' },
-			...pages.filter((page) => !['/', '/about', '/settings'].includes(page.href || '')), // avoid duplicates with static navigation links
-			{
-				name: i18n.t('command.search_zettelkasten'),
-				keywords: ['algolia', 'search', 'notes', 'knowledge', 'second brain'],
-				icon: Search,
-				action: handleDocsearch
-			},
-			{
-				name: i18n.t('common.settings'),
-				keywords: ['preferences'],
-				icon: Settings,
-				href: '/settings'
-			},
-			{
-				name: i18n.t('command.keyboard_shortcuts'),
-				keywords: ['help', 'hotkeys'],
-				icon: Keyboard,
-				action: () => {
-					$showHelp = true;
-					$isCommandActive = false;
-				}
-			},
-			{
-				name: i18n.t('command.export_data'),
-				value: 'export data, backup, download data',
-				icon: Download,
-				href: '/export'
-			},
-			{
-				name: i18n.t('command.go_forward'),
-				icon: ArrowRight,
-				action: () => window.history.forward()
-			},
-			{ name: i18n.t('command.go_back'), icon: ArrowLeft, action: () => window.history.back() },
-			{ name: i18n.t('command.reload'), icon: ArrowLeft, action: reloadPage }
-		]
-			.map(enrichLink)
-			.filter((link) => {
+	let commandConfig = $derived.by(() => {
+		const config: Record<string, CommandData[]> = {
+			navigation: [
+				enrichLink({ name: i18n.t('common.home'), icon: Home, href: '/' }),
+				enrichLink({ name: i18n.t('common.about'), icon: User, href: '/about' }),
+				...pages
+					.filter((page) => !['/', '/about', '/settings'].includes(page.href || ''))
+					.map((p) => enrichLink(p)),
+				enrichLink(
+					{
+						name: i18n.t('command.search_zettelkasten'),
+						keywords: ['algolia', 'search', 'notes', 'knowledge', 'second brain'],
+						icon: Search,
+						action: handleDocsearch
+					},
+					'command.search_zettelkasten'
+				),
+				enrichLink(
+					{
+						name: i18n.t('common.settings'),
+						keywords: ['preferences'],
+						icon: Settings,
+						href: '/settings'
+					},
+					'common.settings'
+				),
+				enrichLink(
+					{
+						name: i18n.t('command.keyboard_shortcuts'),
+						keywords: ['help', 'hotkeys'],
+						icon: Keyboard,
+						action: () => {
+							$showHelp = true;
+							$isCommandActive = false;
+						}
+					},
+					'command.keyboard_shortcuts'
+				),
+				enrichLink(
+					{
+						name: i18n.t('command.export_data'),
+						value: 'export data, backup, download data',
+						icon: Download,
+						href: '/export'
+					},
+					'command.export_data'
+				),
+				enrichLink(
+					{
+						name: i18n.t('command.go_forward'),
+						icon: ArrowRight,
+						action: () => window.history.forward()
+					},
+					'command.go_forward'
+				),
+				enrichLink(
+					{
+						name: i18n.t('command.go_back'),
+						icon: ArrowLeft,
+						action: () => window.history.back()
+					},
+					'command.go_back'
+				),
+				enrichLink(
+					{ name: i18n.t('command.reload'), icon: ArrowLeft, action: reloadPage },
+					'command.reload'
+				)
+			].filter((link) => {
 				// remove current page from navigation
 				return page.url.pathname !== link.href;
 			}),
-		links: externalLinks,
-		system: [
-			{
-				name: i18n.t('command.toggle_dark_mode'),
-				value: 'toggle dark mode, theme, light',
-				icon: $mode === 'light' ? Sun : Moon,
-				action: toggleMode
-			},
-			{
-				name: i18n.t('command.switch_language'),
-				value:
-					'switch language, change language, sprache wechseln, german, english, deutsch, englisch',
-				icon: Globe,
-				action: async () => {
-					const newLanguage = i18n.lang === 'en' ? 'de' : 'en';
-					await i18n.setLanguage(newLanguage);
-					toast.success(i18n.t('command.language_switched'));
-					$isCommandActive = false;
-				}
-			},
-			{
-				name: $debug ? i18n.t('command.disable_debug_mode') : i18n.t('command.enable_debug_mode'),
-				icon: $debug ? BugOff : Bug,
-				action: toggleDebug
-			},
-			{
-				name: i18n.t('command.reset_desktop_files'),
-				value: 'reset desktop files, restore file positions, clear desktop',
-				icon: RotateCcw,
-				action: () => {
-					resetDesktopFiles();
-					toast.success(i18n.t('command.reset_desktop_success'));
-					$isCommandActive = false;
-				}
-			},
-			...(() => {
-				// Only show "Create Desktop Shortcut" if current page has a bookmark entry
-				const currentPage = pages.find(
-					(p) =>
-						p.href === page.url.pathname ||
-						p.name.toLowerCase() === page.url.pathname.replace(/^\//, '')
-				);
-				if (!currentPage || page.url.pathname === '/') return [];
-
-				return [
+			links: externalLinks,
+			system: [
+				enrichLink(
 					{
-						name: i18n.t('command.create_desktop_shortcut'),
-						value: 'create desktop shortcut, add to desktop, pin to desktop',
-						keywords: ['shortcut', 'desktop', 'add', 'pin', 'create'],
-						icon: Plus,
-						action: () => {
-							const fileId =
-								currentPage.name.toLocaleLowerCase() ||
-								currentPage.href?.replace(/\//g, '') ||
-								'page';
-							const existingFile = $desktopFiles.find((f) => f.id === fileId);
-							if (existingFile && !existingFile.hidden) {
-								toast.info(i18n.t('command.shortcut_exists'));
-							} else {
-								addFileToDesktop({
-									id: fileId,
-									name: currentPage.name,
-									href: currentPage.href || '/' + currentPage.name.toLowerCase(),
-									icon: currentPage.icon
-								});
-								toast.success(i18n.t('command.shortcut_added', { name: currentPage.name }));
-							}
+						name: i18n.t('command.toggle_dark_mode'),
+						value: 'toggle dark mode, theme, light',
+						icon: $mode === 'light' ? Sun : Moon,
+						action: toggleMode
+					},
+					'command.toggle_dark_mode'
+				),
+				enrichLink(
+					{
+						name: i18n.t('command.switch_language'),
+						value:
+							'switch language, change language, sprache wechseln, german, english, deutsch, englisch',
+						icon: Globe,
+						action: async () => {
+							const newLanguage = i18n.lang === 'en' ? 'de' : 'en';
+							await i18n.setLanguage(newLanguage);
+							toast.success(i18n.t('command.language_switched'));
 							$isCommandActive = false;
 						}
-					}
-				];
-			})()
-		],
-		fun: [
-			{
-				name: i18n.t('command.confetti'),
-				keywords: ['party', 'celebrate'],
-				icon: PartyPopper,
-				action: () => {
-					confetti();
-				}
-			}
-		],
-		settings: [
-			{
-				name: i18n.t('settings.screensaver'),
-				icon: Monitor,
-				group: 'screensaver',
-				action: () => {
-					currentGroup = 'screensaver';
-					query = '';
-				}
-			}
-		],
-		screensaver: [
-			{
-				name: i18n.t('settings.screensaver_none'),
-				action: () => {
-					$screensaver = 'none';
-					$isCommandActive = false;
-					currentGroup = null;
-				}
-			},
-			{
-				name: i18n.t('settings.screensaver_dvd'),
-				action: () => {
-					$screensaver = 'dvd';
-					$isCommandActive = false;
-					currentGroup = null;
-				}
-			},
-			{
-				name: i18n.t('settings.screensaver_playlists'),
-				action: () => {
-					$screensaver = 'playlists';
-					$isCommandActive = false;
-					currentGroup = null;
-				}
-			},
-			{
-				name: i18n.t('command.go_back'),
-				icon: ArrowLeft,
-				action: () => (currentGroup = null)
-			}
-		].map(enrichLink)
-	} as Record<string, CommandData[]>);
+					},
+					'command.switch_language'
+				),
+				enrichLink(
+					{
+						name: $debug
+							? i18n.t('command.disable_debug_mode')
+							: i18n.t('command.enable_debug_mode'),
+						icon: $debug ? BugOff : Bug,
+						action: toggleDebug
+					},
+					'command.toggle_debug_mode'
+				),
+				enrichLink(
+					{
+						name: i18n.t('command.reset_desktop_files'),
+						value: 'reset desktop files, restore file positions, clear desktop',
+						icon: RotateCcw,
+						action: () => {
+							resetDesktopFiles();
+							toast.success(i18n.t('command.reset_desktop_success'));
+							$isCommandActive = false;
+						}
+					},
+					'command.reset_desktop_files'
+				),
+				...(() => {
+					// Only show "Create Desktop Shortcut" if current page has a bookmark entry
+					const currentPage = pages.find(
+						(p) =>
+							p.href === page.url.pathname ||
+							p.name.toLowerCase() === page.url.pathname.replace(/^\//, '')
+					);
+					if (!currentPage || page.url.pathname === '/') return [];
+
+					return [
+						enrichLink(
+							{
+								name: i18n.t('command.create_desktop_shortcut'),
+								value: 'create desktop shortcut, add to desktop, pin to desktop',
+								keywords: ['shortcut', 'desktop', 'add', 'pin', 'create'],
+								icon: Plus,
+								action: () => {
+									const fileId =
+										currentPage.name.toLocaleLowerCase() ||
+										currentPage.href?.replace(/\//g, '') ||
+										'page';
+									const existingFile = $desktopFiles.find((f) => f.id === fileId);
+									if (existingFile && !existingFile.hidden) {
+										toast.info(i18n.t('command.shortcut_exists'));
+									} else {
+										addFileToDesktop({
+											id: fileId,
+											name: currentPage.name,
+											href: currentPage.href || '/' + currentPage.name.toLowerCase(),
+											icon: currentPage.icon
+										});
+										toast.success(i18n.t('command.shortcut_added', { name: currentPage.name }));
+									}
+									$isCommandActive = false;
+								}
+							},
+							'command.create_desktop_shortcut'
+						)
+					];
+				})()
+			],
+			fun: [
+				enrichLink(
+					{
+						name: i18n.t('command.confetti'),
+						keywords: ['party', 'celebrate'],
+						icon: PartyPopper,
+						action: () => {
+							confetti();
+						}
+					},
+					'command.confetti'
+				)
+			],
+			settings: [
+				enrichLink(
+					{
+						name: i18n.t('settings.screensaver'),
+						icon: Monitor,
+						group: 'screensaver',
+						action: () => {
+							currentGroup = 'screensaver';
+							query = '';
+						}
+					},
+					'settings.screensaver'
+				)
+			],
+			screensaver: [
+				enrichLink(
+					{
+						name: i18n.t('settings.screensaver_none'),
+						action: () => {
+							$screensaver = 'none';
+							$isCommandActive = false;
+							currentGroup = null;
+						}
+					},
+					'settings.screensaver_none'
+				),
+				enrichLink(
+					{
+						name: i18n.t('settings.screensaver_dvd'),
+						action: () => {
+							$screensaver = 'dvd';
+							$isCommandActive = false;
+							currentGroup = null;
+						}
+					},
+					'settings.screensaver_dvd'
+				),
+				enrichLink(
+					{
+						name: i18n.t('settings.screensaver_playlists'),
+						action: () => {
+							$screensaver = 'playlists';
+							$isCommandActive = false;
+							currentGroup = null;
+						}
+					},
+					'settings.screensaver_playlists'
+				),
+				enrichLink(
+					{
+						name: i18n.t('command.go_back'),
+						icon: ArrowLeft,
+						action: () => (currentGroup = null)
+					},
+					'command.go_back_screensaver'
+				)
+			]
+		};
+
+		// Add Suggestions group if we have any tracked commands
+		const allCommands = Object.values(config).flat();
+		const suggestions = Object.entries($commandStats)
+			.map(([id, stat]) => {
+				const command = allCommands.find((c) => c.id === id);
+				if (!command) return null;
+				// Scoring: count + recency bonus (linear decay over 7 days)
+				const sevenDays = 7 * 24 * 60 * 60 * 1000;
+				const recencyBonus = Math.max(0, 1 - (Date.now() - stat.lastUsed) / sevenDays) * 10;
+				const score = stat.count + recencyBonus;
+				return { command, score };
+			})
+			.filter((s): s is { command: CommandData; score: number } => s !== null)
+			.sort((a, b) => b.score - a.score)
+			.slice(0, $suggestionsLimit)
+			.map((s) => s.command);
+
+		if (suggestions.length > 0) {
+			return { suggestions, ...config };
+		}
+
+		return config;
+	});
 
 	// Collect all sub-group names referenced by command items (e.g. 'screensaver')
 	const subGroups = $derived(

--- a/src/routes/Command.svelte
+++ b/src/routes/Command.svelte
@@ -359,8 +359,17 @@
 			};
 
 		const wrappedAction = () => {
-			trackCommand(id);
+			const isInternalNavigation = !!link.group || id === 'command.go_back_screensaver';
+
+			if (!isInternalNavigation) {
+				$isCommandActive = false;
+			}
+
 			action();
+
+			setTimeout(() => {
+				trackCommand(id);
+			}, 0);
 		};
 
 		let value = link.value || link.name;
@@ -498,7 +507,6 @@
 							const newLanguage = i18n.lang === 'en' ? 'de' : 'en';
 							await i18n.setLanguage(newLanguage);
 							toast.success(i18n.t('command.language_switched'));
-							$isCommandActive = false;
 						}
 					},
 					'command.switch_language'
@@ -521,7 +529,6 @@
 						action: () => {
 							resetDesktopFiles();
 							toast.success(i18n.t('command.reset_desktop_success'));
-							$isCommandActive = false;
 						}
 					},
 					'command.reset_desktop_files'
@@ -559,7 +566,6 @@
 										});
 										toast.success(i18n.t('command.shortcut_added', { name: currentPage.name }));
 									}
-									$isCommandActive = false;
 								}
 							},
 							'command.create_desktop_shortcut'
@@ -600,7 +606,6 @@
 						name: i18n.t('settings.screensaver_none'),
 						action: () => {
 							$screensaver = 'none';
-							$isCommandActive = false;
 							currentGroup = null;
 						}
 					},
@@ -611,7 +616,6 @@
 						name: i18n.t('settings.screensaver_dvd'),
 						action: () => {
 							$screensaver = 'dvd';
-							$isCommandActive = false;
 							currentGroup = null;
 						}
 					},
@@ -622,7 +626,6 @@
 						name: i18n.t('settings.screensaver_playlists'),
 						action: () => {
 							$screensaver = 'playlists';
-							$isCommandActive = false;
 							currentGroup = null;
 						}
 					},

--- a/src/routes/Command.svelte
+++ b/src/routes/Command.svelte
@@ -62,8 +62,6 @@
 	import { goto } from '$app/navigation';
 	import {
 		capitalize,
-		hexToHsl,
-		isMobile,
 		reloadPage,
 		scrollToBottom,
 		scrollToTop,
@@ -336,7 +334,7 @@
 		loadingProgress.set(loading ? 100 : 0);
 	});
 
-	const enrichLink = (link: CommandData, translationKey?: string): CommandData => {
+	const enrichLink = (link: CommandData, translationKey?: string, isGroup?: boolean): CommandData => {
 		let href = link.href || '';
 		if (!link.href && !link.action) {
 			href = '/' + link.name.toLowerCase();
@@ -363,13 +361,12 @@
 
 			if (!isInternalNavigation) {
 				$isCommandActive = false;
+				query = '';
 			}
 
 			action();
 
-			setTimeout(() => {
-				trackCommand(id);
-			}, 0);
+			if (!isGroup) trackCommand(id);
 		};
 
 		let value = link.value || link.name;
@@ -603,33 +600,36 @@
 			screensaver: [
 				enrichLink(
 					{
-						name: i18n.t('settings.screensaver_none'),
+						name: i18n.t('settings.screensaver_none') + ($screensaver === 'none' ? ` ✓` : ''),
 						action: () => {
 							$screensaver = 'none';
 							currentGroup = null;
 						}
 					},
-					'settings.screensaver_none'
+					'settings.screensaver_none',
+					true
 				),
 				enrichLink(
 					{
-						name: i18n.t('settings.screensaver_dvd'),
+						name: i18n.t('settings.screensaver_dvd') + ($screensaver === 'dvd' ? ` ✓` : ''),
 						action: () => {
 							$screensaver = 'dvd';
 							currentGroup = null;
 						}
 					},
-					'settings.screensaver_dvd'
+					'settings.screensaver_dvd',
+					true
 				),
 				enrichLink(
 					{
-						name: i18n.t('settings.screensaver_playlists'),
+						name: i18n.t('settings.screensaver_playlists') + ($screensaver === 'playlists' ? ` ✓` : ''),
 						action: () => {
 							$screensaver = 'playlists';
 							currentGroup = null;
 						}
 					},
-					'settings.screensaver_playlists'
+					'settings.screensaver_playlists',
+					true
 				),
 				enrichLink(
 					{
@@ -637,7 +637,8 @@
 						icon: ArrowLeft,
 						action: () => (currentGroup = null)
 					},
-					'command.go_back_screensaver'
+					'command.go_back_screensaver',
+					true
 				)
 			]
 		};
@@ -647,14 +648,14 @@
 		const suggestions = Object.entries($commandStats)
 			.map(([id, stat]) => {
 				const command = allCommands.find((c) => c.id === id);
-				if (!command) return null;
+				if (!command || !command.id) return null;
 				// Scoring: count + recency bonus (linear decay over 7 days)
 				const sevenDays = 7 * 24 * 60 * 60 * 1000;
 				const recencyBonus = Math.max(0, 1 - (Date.now() - stat.lastUsed) / sevenDays) * 10;
 				const score = stat.count + recencyBonus;
-				return { command, score };
+				return { command: { ...command, value: 'suggestion-' + command.value }, score };
 			})
-			.filter((s): s is { command: CommandData; score: number } => s !== null)
+			.filter((s): s is { command: CommandData & { value: string }; score: number } => s !== null)
 			.sort((a, b) => b.score - a.score)
 			.slice(0, $suggestionsLimit)
 			.map((s) => s.command);

--- a/src/routes/settings/GeneralSettings.svelte
+++ b/src/routes/settings/GeneralSettings.svelte
@@ -8,8 +8,17 @@
 	import { type SuperForm, type Infer } from 'sveltekit-superforms';
 	import { i18n } from '$lib/i18n/i18n.svelte';
 	import type { SettingsSchema } from './schema';
+	import { suggestionsLimit } from '$lib/stores/app';
+	import * as Select from '$lib/components/ui/select';
 
 	let { form }: { form: SuperForm<Infer<SettingsSchema>> } = $props();
+
+	const suggestionsLimitOptions = $derived(
+		[0, 3, 5, 10, 15, 20].map((v) => ({
+			value: v,
+			label: v === 0 ? i18n.t('settings.none') : v.toString()
+		}))
+	);
 </script>
 
 <div class="grid gap-6">
@@ -34,6 +43,32 @@
 						</div>
 					</RadioGroup.Root>
 				</div>
+			{/snippet}
+		</Form.Control>
+	</Form.Field>
+
+	<Form.Field {form} name="suggestionsLimit" class="flex flex-col justify-between gap-2">
+		<Form.Control>
+			{#snippet children({ props })}
+				<Form.Label>{i18n.t('settings.suggestions_limit')}</Form.Label>
+				<Select.Root
+					type="single"
+					value={$suggestionsLimit.toString()}
+					onValueChange={(v) => {
+						if (v) $suggestionsLimit = parseInt(v);
+					}}
+				>
+					<Select.Trigger {...props}>
+						{$suggestionsLimit === 0
+							? i18n.t('settings.none')
+							: $suggestionsLimit.toString()}
+					</Select.Trigger>
+					<Select.Content>
+						{#each suggestionsLimitOptions as option}
+							<Select.Item value={option.value.toString()} label={option.label} />
+						{/each}
+					</Select.Content>
+				</Select.Root>
 			{/snippet}
 		</Form.Control>
 	</Form.Field>

--- a/src/routes/settings/GeneralSettings.svelte
+++ b/src/routes/settings/GeneralSettings.svelte
@@ -14,7 +14,7 @@
 	let { form }: { form: SuperForm<Infer<SettingsSchema>> } = $props();
 
 	const suggestionsLimitOptions = $derived(
-		[0, 3, 5, 10, 15, 20].map((v) => ({
+		[0, 3, 5, 10, 15].map((v) => ({
 			value: v,
 			label: v === 0 ? i18n.t('settings.none') : v.toString()
 		}))
@@ -47,6 +47,31 @@
 		</Form.Control>
 	</Form.Field>
 
+	<Form.Field {form} name="debug">
+		<Form.Control>
+			<div class="flex flex-row items-start space-x-3 space-y-0 pt-3">
+				<Checkbox
+					checked={$debug}
+					onCheckedChange={(value) => ($debug = !!value)}
+					id="debug-checkbox"
+				/>
+				<div class="space-y-1 leading-none">
+					<Form.Label
+						class="-mt-0.5 flex items-center gap-2"
+						for="debug-checkbox"
+						onclick={() => ($debug = !$debug)}
+					>
+						<span class="pb-1.5">{i18n.t('settings.debug_mode')}</span>
+						<AnimatedToggle visible={$debug}>
+							<Bug class="w-4" />
+						</AnimatedToggle>
+					</Form.Label>
+				</div>
+			</div>
+			<Form.Description>{i18n.t('settings.debug_description')}</Form.Description>
+		</Form.Control>
+	</Form.Field>
+
 	<Form.Field {form} name="suggestionsLimit" class="flex flex-col justify-between gap-2">
 		<Form.Control>
 			{#snippet children({ props })}
@@ -70,31 +95,6 @@
 					</Select.Content>
 				</Select.Root>
 			{/snippet}
-		</Form.Control>
-	</Form.Field>
-
-	<Form.Field {form} name="debug">
-		<Form.Control>
-			<div class="flex flex-row items-start space-x-3 space-y-0 pt-3">
-				<Checkbox
-					checked={$debug}
-					onCheckedChange={(value) => ($debug = !!value)}
-					id="debug-checkbox"
-				/>
-				<div class="space-y-1 leading-none">
-					<Form.Label
-						class="-mt-0.5 flex items-center gap-2"
-						for="debug-checkbox"
-						onclick={() => ($debug = !$debug)}
-					>
-						<span class="pb-1.5">{i18n.t('settings.debug_mode')}</span>
-						<AnimatedToggle visible={$debug}>
-							<Bug class="w-4" />
-						</AnimatedToggle>
-					</Form.Label>
-				</div>
-			</div>
-			<Form.Description>{i18n.t('settings.debug_description')}</Form.Description>
 		</Form.Control>
 	</Form.Field>
 </div>

--- a/src/routes/settings/schema.ts
+++ b/src/routes/settings/schema.ts
@@ -7,6 +7,7 @@ export const settingsSchema = z.object({
     inactivityTimeout: z.number().default(30),
     backgroundTexture: z.string().default('dots'),
     backgroundSize: z.number().default(1),
-    backgroundSpacing: z.number().default(16)
+    backgroundSpacing: z.number().default(16),
+    suggestionsLimit: z.number().default(5)
 });
 export type SettingsSchema = typeof settingsSchema;


### PR DESCRIPTION
This change implements a "Suggestions" group in the command palette that shows more recently and frequently used items at the top. 

Key changes:
- New `commandStats` and `suggestionsLimit` stores in `app.ts` for persistence and configuration.
- Updated `Command.svelte` to track activations and dynamically calculate a "Suggestions" group based on a combined frequency/recency score.
- Added a new setting in `GeneralSettings.svelte` to allow users to customize the number of suggestions shown.
- Localized all new strings in English and German.

---
*PR created automatically by Jules for task [18381031672605614364](https://jules.google.com/task/18381031672605614364) started by @dnnsmnstrr*