### PR TITLE
Add latest message section to ping page

### DIFF
--- a/src/lib/i18n/de.json
+++ b/src/lib/i18n/de.json
@@ -394,7 +394,10 @@
 		"send": "Nachricht senden",
 		"sending": "Wird gesendet...",
 		"success": "Nachricht gesendet!",
-		"error": "Nachricht konnte nicht gesendet werden."
+		"error": "Nachricht konnte nicht gesendet werden.",
+		"latest_message": "Letzte Nachricht",
+		"no_messages": "Keine Nachrichten gefunden.",
+		"fetch_error": "Fehler beim Abrufen der letzten Nachricht."
 	},
 	"api": {
 		"title": "API",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -393,7 +393,10 @@
 		"send": "Send Message",
 		"sending": "Sending...",
 		"success": "Message sent!",
-		"error": "Failed to send message."
+		"error": "Failed to send message.",
+		"latest_message": "Latest Message",
+		"no_messages": "No messages found.",
+		"fetch_error": "Failed to fetch latest message."
 	},
 	"api": {
 		"title": "API",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,3 +36,25 @@ export interface PlaylistItem {
 	imageUrl?: string;
 	isHovered?: boolean;
 }
+
+export interface NtfyMessage {
+	id: string;
+	time: number;
+	expires?: number;
+	event: 'open' | 'keepalive' | 'message' | 'message_delete' | 'message_clear' | 'poll_request';
+	topic: string;
+	sequence_id?: string;
+	message?: string;
+	title?: string;
+	tags?: string[];
+	priority?: number;
+	click?: string;
+	actions?: any[];
+	attachment?: {
+		name: string;
+		url: string;
+		type?: string;
+		size?: number;
+		expires?: number;
+	};
+}

--- a/src/routes/ping/+page.svelte
+++ b/src/routes/ping/+page.svelte
@@ -21,33 +21,35 @@
 	let message = $state('');
 	let loading = $state(false);
 
-	let latestMessage = $state<NtfyMessage | null>(null);
+	let recentMessages = $state<NtfyMessage[]>([]);
 	let loadingLatest = $state(true);
 	let fetchError = $state(false);
 
-	async function fetchLatestMessage() {
+	async function fetchRecentMessages() {
 		loadingLatest = true;
 		fetchError = false;
 		try {
-			const response = await fetch(`${NTFY_URL}/json?poll=1&since=latest`);
+			const response = await fetch(`${NTFY_URL}/json?poll=1&since=all`);
 			if (!response.ok) throw new Error('Failed to fetch');
 
 			const text = await response.text();
 			const lines = text.trim().split('\n');
+			const messages: NtfyMessage[] = [];
 
-			for (let i = lines.length - 1; i >= 0; i--) {
+			for (const line of lines) {
 				try {
-					const msg = JSON.parse(lines[i]) as NtfyMessage;
+					if (!line.trim()) continue;
+					const msg = JSON.parse(line) as NtfyMessage;
 					if (msg.event === 'message') {
-						latestMessage = msg;
-						break;
+						messages.push(msg);
 					}
 				} catch (e) {
 					console.error('Error parsing NDJSON line:', e);
 				}
 			}
+			recentMessages = messages.reverse();
 		} catch (error) {
-			console.error('Error fetching latest message:', error);
+			console.error('Error fetching recent messages:', error);
 			fetchError = true;
 		} finally {
 			loadingLatest = false;
@@ -55,7 +57,7 @@
 	}
 
 	onMount(() => {
-		fetchLatestMessage();
+		fetchRecentMessages();
 	});
 
 	async function sendMessage() {
@@ -71,6 +73,7 @@
 			if (response.ok) {
 				toast.success(i18n.t('ping.success'));
 				message = '';
+				fetchRecentMessages();
 			} else {
 				throw new Error('Failed to send message');
 			}
@@ -131,9 +134,14 @@
 	<Accordion.Root type="single" class="mt-4">
 		<Accordion.Item value="latest">
 			<Accordion.Trigger class="text-sm">
-				<div class="flex items-center gap-2">
-					<InfoIcon class="h-4 w-4" />
-					{i18n.t('ping.latest_message')}
+				<div class="flex items-center gap-2 overflow-hidden pr-4">
+					<InfoIcon class="h-4 w-4 shrink-0" />
+					<span class="shrink-0">{i18n.t('ping.latest_message')}</span>
+					{#if recentMessages.length > 0}
+						<span class="text-muted-foreground truncate text-xs font-normal">
+							— {recentMessages[0].message}
+						</span>
+					{/if}
 				</div>
 			</Accordion.Trigger>
 			<Accordion.Content>
@@ -141,15 +149,19 @@
 					<p class="text-muted-foreground text-sm">{i18n.t('api.loading')}</p>
 				{:else if fetchError}
 					<p class="text-destructive text-sm">{i18n.t('ping.fetch_error')}</p>
-				{:else if latestMessage}
-					<div class="space-y-1">
-						{#if latestMessage.title}
-							<p class="text-sm font-semibold">{latestMessage.title}</p>
-						{/if}
-						<p class="text-sm">{latestMessage.message}</p>
-						<p class="text-muted-foreground text-xs">
-							{getFriendlyTime(new Date(latestMessage.time * 1000))}
-						</p>
+				{:else if recentMessages.length > 0}
+					<div class="divide-y divide-border">
+						{#each recentMessages as msg}
+							<div class="py-3 first:pt-0 last:pb-0">
+								{#if msg.title}
+									<p class="text-sm font-semibold">{msg.title}</p>
+								{/if}
+								<p class="text-sm">{msg.message}</p>
+								<p class="text-muted-foreground text-xs">
+									{getFriendlyTime(new Date(msg.time * 1000))}
+								</p>
+							</div>
+						{/each}
 					</div>
 				{:else}
 					<p class="text-muted-foreground text-sm">{i18n.t('ping.no_messages')}</p>

--- a/src/routes/ping/+page.svelte
+++ b/src/routes/ping/+page.svelte
@@ -5,6 +5,9 @@
 	import Heading from '$lib/components/typography/Heading.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Textarea } from '$lib/components/ui/textarea';
+	import * as Accordion from '$lib/components/ui/accordion';
+	import { getFriendlyTime } from '$lib/utils/helper';
+	import type { NtfyMessage } from '$lib/types';
 	import {
 		Card,
 		CardContent,
@@ -13,10 +16,47 @@
 		CardTitle
 	} from '$lib/components/ui/card';
 	import { toast } from 'svelte-sonner';
-	import { Send } from 'lucide-svelte';
+	import { Send, InfoIcon } from 'lucide-svelte';
 
 	let message = $state('');
 	let loading = $state(false);
+
+	let latestMessage = $state<NtfyMessage | null>(null);
+	let loadingLatest = $state(true);
+	let fetchError = $state(false);
+
+	async function fetchLatestMessage() {
+		loadingLatest = true;
+		fetchError = false;
+		try {
+			const response = await fetch(`${NTFY_URL}/json?poll=1&since=latest`);
+			if (!response.ok) throw new Error('Failed to fetch');
+
+			const text = await response.text();
+			const lines = text.trim().split('\n');
+
+			for (let i = lines.length - 1; i >= 0; i--) {
+				try {
+					const msg = JSON.parse(lines[i]) as NtfyMessage;
+					if (msg.event === 'message') {
+						latestMessage = msg;
+						break;
+					}
+				} catch (e) {
+					console.error('Error parsing NDJSON line:', e);
+				}
+			}
+		} catch (error) {
+			console.error('Error fetching latest message:', error);
+			fetchError = true;
+		} finally {
+			loadingLatest = false;
+		}
+	}
+
+	onMount(() => {
+		fetchLatestMessage();
+	});
 
 	async function sendMessage() {
 		if (!message.trim()) return;
@@ -87,4 +127,34 @@
 			</form>
 		</CardContent>
 	</Card>
+
+	<Accordion.Root type="single" class="mt-4">
+		<Accordion.Item value="latest">
+			<Accordion.Trigger class="text-sm">
+				<div class="flex items-center gap-2">
+					<InfoIcon class="h-4 w-4" />
+					{i18n.t('ping.latest_message')}
+				</div>
+			</Accordion.Trigger>
+			<Accordion.Content>
+				{#if loadingLatest}
+					<p class="text-muted-foreground text-sm">{i18n.t('api.loading')}</p>
+				{:else if fetchError}
+					<p class="text-destructive text-sm">{i18n.t('ping.fetch_error')}</p>
+				{:else if latestMessage}
+					<div class="space-y-1">
+						{#if latestMessage.title}
+							<p class="text-sm font-semibold">{latestMessage.title}</p>
+						{/if}
+						<p class="text-sm">{latestMessage.message}</p>
+						<p class="text-muted-foreground text-xs">
+							{getFriendlyTime(new Date(latestMessage.time * 1000))}
+						</p>
+					</div>
+				{:else}
+					<p class="text-muted-foreground text-sm">{i18n.t('ping.no_messages')}</p>
+				{/if}
+			</Accordion.Content>
+		</Accordion.Item>
+	</Accordion.Root>
 </div>


### PR DESCRIPTION
This change adds an expandable section on the ping page that displays the most recent message sent to the ntfy.sh/muensterer_tech stream. It uses the ntfy.sh API to poll for the latest message and displays it with a relative timestamp.

---
*PR created automatically by Jules for task [12167315412205005835](https://jules.google.com/task/12167315412205005835) started by @dnnsmnstrr*