### PR TITLE
Add message moderation and email link to ping page

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -3,16 +3,22 @@
 > vite dev
 
 
-  VITE v5.4.21  ready in 1503 ms
+  VITE v5.4.21  ready in 1563 ms
 
   ➜  Local:   http://localhost:5173/
   ➜  Network: use --host to expose
+9:25:55 AM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+9:25:55 AM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:27 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
 
 warn - The class `duration-[2000]` is ambiguous and matches multiple utilities.
 warn - If this is content and not a class, replace it with `duration-&lsqb;2000&rsqb;` to silence this warning.
-8:44:11 AM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+9:26:05 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
 https://svelte.dev/e/state_referenced_locally
-8:44:11 AM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:27 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+9:26:05 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:14 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+9:26:05 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:19:11 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
 https://svelte.dev/e/state_referenced_locally
 node_invalid_placement_ssr: `<button>` (src/lib/components/ui/button/button.svelte:66:1) cannot be a child of `<button>` (node_modules/.pnpm/bits-ui@1.8.0_svelte@5.55.9/node_modules/bits-ui/dist/bits/dialog/components/dialog-trigger.svelte:31:1)
 
@@ -23,19 +29,15 @@ This can cause content to shift around as the browser repairs the HTML, and will
 
 warn - The class `duration-[2000]` is ambiguous and matches multiple utilities.
 warn - If this is content and not a class, replace it with `duration-&lsqb;2000&rsqb;` to silence this warning.
-8:44:30 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+9:26:18 AM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
 https://svelte.dev/e/state_referenced_locally
-8:44:30 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:14 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+9:26:18 AM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:27 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
 https://svelte.dev/e/state_referenced_locally
-8:44:30 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:19:11 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+9:26:18 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
 https://svelte.dev/e/state_referenced_locally
-8:44:32 AM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+9:26:18 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:14 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
 https://svelte.dev/e/state_referenced_locally
-8:44:32 AM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:27 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+9:26:18 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:19:11 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
 https://svelte.dev/e/state_referenced_locally
-8:44:33 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-8:44:33 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:14 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
-8:44:33 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:19:11 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
-https://svelte.dev/e/state_referenced_locally
+9:27:10 AM [vite] .env changed, restarting server...
+9:27:10 AM [vite] server restarted.

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,41 @@
+
+> website-next@0.0.1 dev /app
+> vite dev
+
+
+  VITE v5.4.21  ready in 1503 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+
+warn - The class `duration-[2000]` is ambiguous and matches multiple utilities.
+warn - If this is content and not a class, replace it with `duration-&lsqb;2000&rsqb;` to silence this warning.
+8:44:11 AM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+8:44:11 AM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:27 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+node_invalid_placement_ssr: `<button>` (src/lib/components/ui/button/button.svelte:66:1) cannot be a child of `<button>` (node_modules/.pnpm/bits-ui@1.8.0_svelte@5.55.9/node_modules/bits-ui/dist/bits/dialog/components/dialog-trigger.svelte:31:1)
+
+This can cause content to shift around as the browser repairs the HTML, and will likely result in a `hydration_mismatch` warning.
+node_invalid_placement_ssr: `<button>` (src/lib/components/ui/button/button.svelte:66:1) cannot be a child of `<button>` (node_modules/.pnpm/bits-ui@1.8.0_svelte@5.55.9/node_modules/bits-ui/dist/bits/utilities/floating-layer/components/floating-layer-anchor.svelte:34:2)
+
+This can cause content to shift around as the browser repairs the HTML, and will likely result in a `hydration_mismatch` warning.
+
+warn - The class `duration-[2000]` is ambiguous and matches multiple utilities.
+warn - If this is content and not a class, replace it with `duration-&lsqb;2000&rsqb;` to silence this warning.
+8:44:30 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+8:44:30 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:14 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+8:44:30 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:19:11 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+8:44:32 AM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+8:44:32 AM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:27 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+8:44:33 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+8:44:33 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:14 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+8:44:33 AM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:19:11 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally

--- a/jsrepo.json
+++ b/jsrepo.json
@@ -11,6 +11,7 @@
 	"paths": {
 		"*": "./src/blocks",
 		"ui": "./src/lib/components/ui",
+		"component": "./src/lib/components/ui",
 		"actions": "./src/lib/actions",
 		"hooks": "./src/lib/hooks",
 		"utils": "./src/lib/utils"

--- a/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { buttonVariants } from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils";
+
+	let { ref = $bindable(null), class: className, variant = "default", size = "default", ...restProps }: AlertDialogPrimitive.ActionProps & { variant?: any; size?: any } = $props();
+</script>
+
+<AlertDialogPrimitive.Action
+	bind:ref
+	class={cn(buttonVariants({ variant, size }), className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { buttonVariants } from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils";
+
+	let { ref = $bindable(null), class: className, ...restProps }: AlertDialogPrimitive.CancelProps = $props();
+</script>
+
+<AlertDialogPrimitive.Cancel
+	bind:ref
+	class={cn(buttonVariants({ variant: "outline" }), "mt-2 sm:mt-0", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import * as AlertDialog from "./index.js";
+	import { cn } from "$lib/utils";
+
+	let { ref = $bindable(null), class: className, children, ...restProps }: AlertDialogPrimitive.ContentProps = $props();
+</script>
+
+<AlertDialog.Portal>
+	<AlertDialog.Overlay />
+	<AlertDialogPrimitive.Content
+		bind:ref
+		class={cn(
+			"fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+			className
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+	</AlertDialogPrimitive.Content>
+</AlertDialog.Portal>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils";
+
+	let { ref = $bindable(null), class: className, ...restProps }: AlertDialogPrimitive.DescriptionProps = $props();
+</script>
+
+<AlertDialogPrimitive.Description
+	bind:ref
+	class={cn("text-muted-foreground text-sm", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { cn } from "$lib/utils";
+
+	let { class: className, ...restProps }: svelte.JSX.HTMLAttributes<HTMLDivElement> = $props();
+</script>
+
+<div
+	class={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+	{...restProps}
+>
+    {@render restProps.children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import { cn } from "$lib/utils";
+
+	let { class: className, ...restProps }: svelte.JSX.HTMLAttributes<HTMLDivElement> = $props();
+</script>
+
+<div class={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...restProps}>
+    {@render restProps.children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils";
+
+	let { ref = $bindable(null), class: className, ...restProps }: AlertDialogPrimitive.OverlayProps = $props();
+</script>
+
+<AlertDialogPrimitive.Overlay
+	bind:ref
+	class={cn(
+		"fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-portal.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let { ...restProps }: AlertDialogPrimitive.PortalProps = $props();
+</script>
+
+<AlertDialogPrimitive.Portal {...restProps} />

--- a/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils";
+
+	let { ref = $bindable(null), class: className, ...restProps }: AlertDialogPrimitive.TitleProps = $props();
+</script>
+
+<AlertDialogPrimitive.Title
+	bind:ref
+	class={cn("text-lg font-semibold", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/index.ts
+++ b/src/lib/components/ui/alert-dialog/index.ts
@@ -1,0 +1,40 @@
+import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+import Title from "./alert-dialog-title.svelte";
+import Action from "./alert-dialog-action.svelte";
+import Cancel from "./alert-dialog-cancel.svelte";
+import Portal from "./alert-dialog-portal.svelte";
+import Footer from "./alert-dialog-footer.svelte";
+import Header from "./alert-dialog-header.svelte";
+import Overlay from "./alert-dialog-overlay.svelte";
+import Content from "./alert-dialog-content.svelte";
+import Description from "./alert-dialog-description.svelte";
+
+const Root = AlertDialogPrimitive.Root;
+const Trigger = AlertDialogPrimitive.Trigger;
+
+export {
+	Root,
+	Title,
+	Action,
+	Cancel,
+	Portal,
+	Footer,
+	Header,
+	Trigger,
+	Overlay,
+	Content,
+	Description,
+	//
+	Root as AlertDialog,
+	Title as AlertDialogTitle,
+	Action as AlertDialogAction,
+	Cancel as AlertDialogCancel,
+	Portal as AlertDialogPortal,
+	Footer as AlertDialogFooter,
+	Header as AlertDialogHeader,
+	Trigger as AlertDialogTrigger,
+	Overlay as AlertDialogOverlay,
+	Content as AlertDialogContent,
+	Description as AlertDialogDescription,
+};

--- a/src/lib/components/ui/confirm-delete-dialog/confirm-delete-dialog.svelte
+++ b/src/lib/components/ui/confirm-delete-dialog/confirm-delete-dialog.svelte
@@ -1,0 +1,133 @@
+<script lang="ts" module>
+	class ConfirmDeleteDialogState {
+		open = $state(false);
+		inputText = $state('');
+		options = $state<ConfirmDeleteOptions | null>(null);
+		loading = $state(false);
+
+		constructor() {
+			this.confirm = this.confirm.bind(this);
+			this.cancel = this.cancel.bind(this);
+		}
+
+		newConfirmation(options: ConfirmDeleteOptions) {
+			this.reset();
+			this.options = options;
+			this.open = true;
+		}
+
+		reset() {
+			this.open = false;
+			this.inputText = '';
+			this.options = null;
+		}
+
+		confirm() {
+			if (this.options?.input) {
+				if (this.inputText !== this.options.input.confirmationText) {
+					return;
+				}
+			}
+
+			this.loading = true;
+			this.options
+				?.onConfirm()
+				.then(() => {
+					this.open = false;
+				})
+				.finally(() => {
+					this.loading = false;
+				});
+		}
+
+		cancel() {
+			this.options?.onCancel?.();
+			this.open = false;
+		}
+	}
+
+	const dialogState = new ConfirmDeleteDialogState();
+
+	export type ConfirmDeleteOptions = {
+		title: string;
+		description: string;
+		skipConfirmation?: boolean;
+		input?: {
+			confirmationText: string;
+		};
+		confirm?: {
+			text?: string;
+		};
+		cancel?: {
+			text?: string;
+		};
+		onConfirm: () => Promise<unknown>;
+		onCancel?: () => void;
+	};
+
+	export function confirmDelete(options: ConfirmDeleteOptions) {
+		if (options.skipConfirmation) {
+			options.onConfirm();
+			return;
+		}
+
+		dialogState.newConfirmation(options);
+	}
+</script>
+
+<script lang="ts">
+	import * as AlertDialog from '$lib/components/ui/alert-dialog';
+	import { Input } from '$lib/components/ui/input';
+	import { Loader2 } from 'lucide-svelte';
+</script>
+
+<AlertDialog.Root bind:open={dialogState.open}>
+	<AlertDialog.Content>
+		<form
+			method="POST"
+			onsubmit={(e) => {
+				e.preventDefault();
+				dialogState.confirm();
+			}}
+			class="flex flex-col gap-4"
+		>
+			<AlertDialog.Header>
+				<AlertDialog.Title>
+					{dialogState.options?.title}
+				</AlertDialog.Title>
+				<AlertDialog.Description>
+					{dialogState.options?.description}
+				</AlertDialog.Description>
+			</AlertDialog.Header>
+			{#if dialogState.options?.input}
+				<Input
+					bind:value={dialogState.inputText}
+					placeholder={`Enter "${dialogState.options.input.confirmationText}" to confirm.`}
+					onkeydown={(e) => {
+						if (e.key === 'Enter') {
+							// for some reason without this the form will submit and the dialog will close immediately
+							e.preventDefault();
+							dialogState.confirm();
+						}
+					}}
+				/>
+			{/if}
+			<AlertDialog.Footer>
+				<AlertDialog.Cancel type="button" onclick={dialogState.cancel}>
+					{dialogState.options?.cancel?.text ?? 'Cancel'}
+				</AlertDialog.Cancel>
+				<AlertDialog.Action
+					type="submit"
+					variant="destructive"
+					disabled={dialogState.loading || (dialogState.options?.input &&
+						dialogState.inputText !== dialogState.options.input.confirmationText)}
+				>
+					{#if dialogState.loading}
+						<Loader2 class="mr-2 h-4 w-4 animate-spin" />
+					{/if}
+					{dialogState.options?.confirm?.text ?? 'Delete'}
+				</AlertDialog.Action>
+			</AlertDialog.Footer>
+		</form>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/lib/components/ui/confirm-delete-dialog/index.ts
+++ b/src/lib/components/ui/confirm-delete-dialog/index.ts
@@ -1,0 +1,6 @@
+import ConfirmDeleteDialog, {
+	confirmDelete,
+	type ConfirmDeleteOptions
+} from './confirm-delete-dialog.svelte';
+
+export { ConfirmDeleteDialog, confirmDelete, type ConfirmDeleteOptions };

--- a/src/lib/i18n/de.json
+++ b/src/lib/i18n/de.json
@@ -397,7 +397,14 @@
 		"error": "Nachricht konnte nicht gesendet werden.",
 		"latest_message": "Letzte Nachricht",
 		"no_messages": "Keine Nachrichten gefunden.",
-		"fetch_error": "Fehler beim Abrufen der letzten Nachricht."
+		"fetch_error": "Fehler beim Abrufen der letzten Nachricht.",
+		"email_prefix": "Alternativ kannst du eine E-Mail an ",
+		"email_suffix": " senden, um eine Nachricht auszulösen.",
+		"clear_all": "Alle Nachrichten löschen",
+		"clearing": "Nachrichten werden gelöscht...",
+		"clear_confirm": "Bist du sicher, dass du alle angezeigten Nachrichten löschen möchtest? Dies wird sie vom ntfy.sh Server entfernen.",
+		"clear_success": "Alle Nachrichten gelöscht!",
+		"clear_error": "Fehler beim Löschen einiger Nachrichten."
 	},
 	"api": {
 		"title": "API",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -396,7 +396,14 @@
 		"error": "Failed to send message.",
 		"latest_message": "Latest Message",
 		"no_messages": "No messages found.",
-		"fetch_error": "Failed to fetch latest message."
+		"fetch_error": "Failed to fetch latest message.",
+		"email_prefix": "Alternatively, you can send an email to ",
+		"email_suffix": " to trigger a message.",
+		"clear_all": "Clear All Messages",
+		"clearing": "Clearing messages...",
+		"clear_confirm": "Are you sure you want to clear all displayed messages? This will delete them from the ntfy.sh server.",
+		"clear_success": "All messages cleared!",
+		"clear_error": "Failed to clear some messages."
 	},
 	"api": {
 		"title": "API",

--- a/src/routes/ping/+page.svelte
+++ b/src/routes/ping/+page.svelte
@@ -165,6 +165,7 @@
 
 					if (failCount === 0) {
 						toast.success(i18n.t('ping.clear_success'));
+						recentMessages = [];
 					} else {
 						const errorMessage = needsToken
 							? `${i18n.t('ping.clear_error')} (Admin token required)`
@@ -177,7 +178,10 @@
 					}
 				} finally {
 					clearing = false;
-					fetchRecentMessages();
+					// Wait a bit for the ntfy server to reflect changes
+					setTimeout(() => {
+						fetchRecentMessages();
+					}, 500);
 				}
 			}
 		});

--- a/src/routes/ping/+page.svelte
+++ b/src/routes/ping/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 	import { i18n } from '$lib/i18n/i18n.svelte';
-	import { PAGE_TITLE_SUFFIX, NTFY_URL } from '$lib/config';
+	import { PAGE_TITLE_SUFFIX, NTFY_URL, NTFY_TOPIC, USERNAME_SHORT } from '$lib/config';
 	import Heading from '$lib/components/typography/Heading.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { Textarea } from '$lib/components/ui/textarea';
@@ -16,15 +17,40 @@
 		CardTitle
 	} from '$lib/components/ui/card';
 	import { toast } from 'svelte-sonner';
-	import { Send, InfoIcon } from 'lucide-svelte';
+	import { Send, InfoIcon, Trash2 } from 'lucide-svelte';
 	import { Kbd } from '$lib/components/typography';
 
 	let message = $state('');
 	let loading = $state(false);
+	let clearing = $state(false);
+	let isAdmin = $state(false);
 
 	let recentMessages = $state<NtfyMessage[]>([]);
 	let loadingLatest = $state(true);
 	let fetchError = $state(false);
+
+	const ntfyEmail = `ntfy-${NTFY_TOPIC}@ntfy.sh`;
+
+	async function checkAdminStatus() {
+		if (!browser) return;
+		const token = localStorage.getItem('github_admin_token');
+		if (!token) return;
+
+		try {
+			const response = await fetch('https://api.github.com/user', {
+				headers: {
+					Authorization: `token ${token}`,
+					Accept: 'application/vnd.github.v3+json'
+				}
+			});
+			if (response.ok) {
+				const userData = await response.json();
+				isAdmin = userData.login === USERNAME_SHORT;
+			}
+		} catch (error) {
+			console.error('Failed to verify admin status:', error);
+		}
+	}
 
 	async function fetchRecentMessages() {
 		loadingLatest = true;
@@ -36,6 +62,7 @@
 			const text = await response.text();
 			const lines = text.trim().split('\n');
 			const messages: NtfyMessage[] = [];
+			const deletedIds = new Set<string>();
 
 			for (const line of lines) {
 				try {
@@ -43,12 +70,19 @@
 					const msg = JSON.parse(line) as NtfyMessage;
 					if (msg.event === 'message') {
 						messages.push(msg);
+					} else if (
+						(msg.event === 'message_delete' || msg.event === 'message_clear') &&
+						msg.sequence_id
+					) {
+						deletedIds.add(msg.sequence_id);
 					}
 				} catch (e) {
 					console.error('Error parsing NDJSON line:', e);
 				}
 			}
-			recentMessages = messages.reverse();
+			recentMessages = messages
+				.filter((m) => !deletedIds.has(m.id) && (!m.sequence_id || !deletedIds.has(m.sequence_id)))
+				.reverse();
 		} catch (error) {
 			console.error('Error fetching recent messages:', error);
 			fetchError = true;
@@ -59,6 +93,7 @@
 
 	onMount(() => {
 		fetchRecentMessages();
+		checkAdminStatus();
 	});
 
 	async function sendMessage() {
@@ -85,6 +120,44 @@
 			loading = false;
 		}
 	}
+
+	async function clearAllMessages() {
+		if (recentMessages.length === 0) return;
+		if (!confirm(i18n.t('ping.clear_confirm'))) return;
+
+		clearing = true;
+		let successCount = 0;
+		let failCount = 0;
+
+		try {
+			for (const msg of recentMessages) {
+				try {
+					const response = await fetch(`${NTFY_URL}?id=${msg.id}`, {
+						method: 'DELETE'
+					});
+					if (response.ok) {
+						successCount++;
+					} else {
+						failCount++;
+					}
+				} catch (e) {
+					console.error(`Failed to delete message ${msg.id}:`, e);
+					failCount++;
+				}
+			}
+
+			if (failCount === 0) {
+				toast.success(i18n.t('ping.clear_success'));
+			} else if (successCount > 0) {
+				toast.warning(i18n.t('ping.clear_error'));
+			} else {
+				toast.error(i18n.t('ping.clear_error'));
+			}
+		} finally {
+			clearing = false;
+			fetchRecentMessages();
+		}
+	}
 </script>
 
 <svelte:head>
@@ -96,7 +169,13 @@
 
 	<Card class="mt-8">
 		<CardHeader>
-			<CardDescription>{i18n.t('ping.description')}</CardDescription>
+			<CardDescription>
+				{i18n.t('ping.description')}
+				<br />
+				{i18n.t('ping.email_prefix')}
+				<a href="mailto:{ntfyEmail}" class="text-primary hover:underline">{ntfyEmail}</a>
+				{i18n.t('ping.email_suffix')}
+			</CardDescription>
 		</CardHeader>
 		<CardContent>
 			<form
@@ -165,6 +244,24 @@
 							</div>
 						{/each}
 					</div>
+
+					{#if isAdmin}
+						<div class="mt-4 flex justify-end">
+							<Button
+								variant="destructive"
+								size="sm"
+								disabled={clearing}
+								onclick={() => clearAllMessages()}
+							>
+								{#if clearing}
+									{i18n.t('ping.clearing')}
+								{:else}
+									<Trash2 class="mr-2 h-4 w-4" />
+									{i18n.t('ping.clear_all')}
+								{/if}
+							</Button>
+						</div>
+					{/if}
 				{:else}
 					<p class="text-muted-foreground text-sm">{i18n.t('ping.no_messages')}</p>
 				{/if}

--- a/src/routes/ping/+page.svelte
+++ b/src/routes/ping/+page.svelte
@@ -19,6 +19,7 @@
 	import { toast } from 'svelte-sonner';
 	import { Send, InfoIcon, Trash2 } from 'lucide-svelte';
 	import { Kbd } from '$lib/components/typography';
+	import { ConfirmDeleteDialog, confirmDelete } from '$lib/components/ui/confirm-delete-dialog';
 
 	let message = $state('');
 	let loading = $state(false);
@@ -123,41 +124,49 @@
 
 	async function clearAllMessages() {
 		if (recentMessages.length === 0) return;
-		if (!confirm(i18n.t('ping.clear_confirm'))) return;
 
-		clearing = true;
-		let successCount = 0;
-		let failCount = 0;
+		confirmDelete({
+			title: i18n.t('ping.clear_all'),
+			description: i18n.t('ping.clear_confirm'),
+			confirm: { text: i18n.t('common.yes') },
+			cancel: { text: i18n.t('common.no') },
+			onConfirm: async () => {
+				clearing = true;
+				let successCount = 0;
+				let failCount = 0;
 
-		try {
-			for (const msg of recentMessages) {
 				try {
-					const response = await fetch(`${NTFY_URL}?id=${msg.id}`, {
-						method: 'DELETE'
-					});
-					if (response.ok) {
-						successCount++;
-					} else {
-						failCount++;
+					for (const msg of recentMessages) {
+						try {
+							const response = await fetch(`${NTFY_URL}?id=${msg.id}`, {
+								method: 'DELETE'
+							});
+							if (response.ok) {
+								successCount++;
+							} else {
+								failCount++;
+							}
+						} catch (e) {
+							console.error(`Failed to delete message ${msg.id}:`, e);
+							failCount++;
+						}
 					}
-				} catch (e) {
-					console.error(`Failed to delete message ${msg.id}:`, e);
-					failCount++;
+
+					if (failCount === 0) {
+						toast.success(i18n.t('ping.clear_success'));
+					} else if (successCount > 0) {
+						toast.warning(i18n.t('ping.clear_error'));
+					} else {
+						toast.error(i18n.t('ping.clear_error'));
+					}
+				} finally {
+					clearing = false;
+					fetchRecentMessages();
 				}
 			}
-
-			if (failCount === 0) {
-				toast.success(i18n.t('ping.clear_success'));
-			} else if (successCount > 0) {
-				toast.warning(i18n.t('ping.clear_error'));
-			} else {
-				toast.error(i18n.t('ping.clear_error'));
-			}
-		} finally {
-			clearing = false;
-			fetchRecentMessages();
-		}
+		});
 	}
+
 </script>
 
 <svelte:head>
@@ -211,6 +220,8 @@
 			</form>
 		</CardContent>
 	</Card>
+
+	<ConfirmDeleteDialog />
 
 	<Accordion.Root type="single" class="mt-4">
 		<Accordion.Item value="latest">

--- a/src/routes/ping/+page.svelte
+++ b/src/routes/ping/+page.svelte
@@ -136,14 +136,25 @@
 				let failCount = 0;
 
 				try {
+					const ntfyToken = localStorage.getItem('ntfy_admin_token');
+					let needsToken = false;
 					for (const msg of recentMessages) {
 						try {
-							const response = await fetch(`${NTFY_URL}?id=${msg.id}`, {
-								method: 'DELETE'
+							const idToDelete = msg.id;
+							const response = await fetch(`${NTFY_URL}/${idToDelete}`, {
+								method: 'DELETE',
+								headers: ntfyToken
+									? {
+											Authorization: `Bearer ${ntfyToken}`
+										}
+									: {}
 							});
 							if (response.ok) {
 								successCount++;
 							} else {
+								if (response.status === 401 || response.status === 403) {
+									needsToken = true;
+								}
 								failCount++;
 							}
 						} catch (e) {
@@ -154,10 +165,15 @@
 
 					if (failCount === 0) {
 						toast.success(i18n.t('ping.clear_success'));
-					} else if (successCount > 0) {
-						toast.warning(i18n.t('ping.clear_error'));
 					} else {
-						toast.error(i18n.t('ping.clear_error'));
+						const errorMessage = needsToken
+							? `${i18n.t('ping.clear_error')} (Admin token required)`
+							: i18n.t('ping.clear_error');
+						if (successCount > 0) {
+							toast.warning(errorMessage);
+						} else {
+							toast.error(errorMessage);
+						}
 					}
 				} finally {
 					clearing = false;


### PR DESCRIPTION
This PR implements moderation features for the ping page to handle arbitrary user content.

Key changes:
1. **Admin Verification**: Sensitive actions like clearing messages are now restricted. The application verifies the user's identity by checking their GitHub login (via the stored admin token) against the website owner's username.
2. **Clear All Functionality**: Admins can now clear all messages displayed in the "Latest Messages" section. This sends DELETE requests to ntfy.sh for each message.
3. **Improved Filtering**: The message list now correctly filters out messages that have been deleted or cleared, using event tracking from the ntfy NDJSON stream.
4. **Mailto Link**: Added a direct link to trigger messages via email, as requested.
5. **i18n**: Added necessary strings for both English and German locales.

---
*PR created automatically by Jules for task [7024473961630591126](https://jules.google.com/task/7024473961630591126) started by @dnnsmnstrr*