### PR TITLE
Improve mobile command palette scrolling and positioning

### DIFF
--- a/src/lib/components/ui/command/command-dialog.svelte
+++ b/src/lib/components/ui/command/command-dialog.svelte
@@ -22,7 +22,7 @@
 		} = $props();
 </script>
 
-<Dialog.Root bind:open {...restProps}>
+<Dialog.Root bind:open {...restProps} preventScroll={true}>
 	<Dialog.Content class="top-[5vh] overflow-hidden p-0 translate-y-0 sm:top-[50%] sm:-translate-y-40 shadow-lg w-[95vw] sm:w-full max-w-lg" {portalProps}>
 		<Command
 			class="[&_[data-command-group]:not([hidden])_~[data-command-group]]:pt-0 [&_[data-command-group]]:px-2 [&_[data-command-input-wrapper]_svg]:h-5 [&_[data-command-input-wrapper]_svg]:w-5 [&_[data-command-input]]:h-12 [&_[data-command-item]]:px-2 [&_[data-command-item]]:py-3 [&_[data-command-item]_svg]:h-5 [&_[data-command-item]_svg]:w-5"

--- a/src/lib/components/ui/command/command-dialog.svelte
+++ b/src/lib/components/ui/command/command-dialog.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <Dialog.Root bind:open {...restProps}>
-	<Dialog.Content class="top-[5vh] overflow-hidden p-0 translate-y-0 sm:top-[50%] sm:-translate-y-40 shadow-lg" {portalProps}>
+	<Dialog.Content class="top-[5vh] overflow-hidden p-0 translate-y-0 sm:top-[50%] sm:-translate-y-40 shadow-lg w-[95vw] sm:w-full max-w-lg" {portalProps}>
 		<Command
 			class="[&_[data-command-group]:not([hidden])_~[data-command-group]]:pt-0 [&_[data-command-group]]:px-2 [&_[data-command-input-wrapper]_svg]:h-5 [&_[data-command-input-wrapper]_svg]:w-5 [&_[data-command-input]]:h-12 [&_[data-command-item]]:px-2 [&_[data-command-item]]:py-3 [&_[data-command-item]_svg]:h-5 [&_[data-command-item]_svg]:w-5"
 			{...restProps}

--- a/src/lib/components/ui/command/command-dialog.svelte
+++ b/src/lib/components/ui/command/command-dialog.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <Dialog.Root bind:open {...restProps}>
-	<Dialog.Content class="overflow-hidden p-0 -translate-y-60 sm:-translate-y-40 shadow-lg" {portalProps}>
+	<Dialog.Content class="overflow-hidden p-0 -translate-y-[10vh] sm:-translate-y-40 shadow-lg" {portalProps}>
 		<Command
 			class="[&_[data-command-group]:not([hidden])_~[data-command-group]]:pt-0 [&_[data-command-group]]:px-2 [&_[data-command-input-wrapper]_svg]:h-5 [&_[data-command-input-wrapper]_svg]:w-5 [&_[data-command-input]]:h-12 [&_[data-command-item]]:px-2 [&_[data-command-item]]:py-3 [&_[data-command-item]_svg]:h-5 [&_[data-command-item]_svg]:w-5"
 			{...restProps}

--- a/src/lib/components/ui/command/command-dialog.svelte
+++ b/src/lib/components/ui/command/command-dialog.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <Dialog.Root bind:open {...restProps}>
-	<Dialog.Content class="overflow-hidden p-0 -translate-y-[10vh] sm:-translate-y-40 shadow-lg" {portalProps}>
+	<Dialog.Content class="top-[5vh] overflow-hidden p-0 translate-y-0 sm:top-[50%] sm:-translate-y-40 shadow-lg" {portalProps}>
 		<Command
 			class="[&_[data-command-group]:not([hidden])_~[data-command-group]]:pt-0 [&_[data-command-group]]:px-2 [&_[data-command-input-wrapper]_svg]:h-5 [&_[data-command-input-wrapper]_svg]:w-5 [&_[data-command-input]]:h-12 [&_[data-command-item]]:px-2 [&_[data-command-item]]:py-3 [&_[data-command-item]_svg]:h-5 [&_[data-command-item]_svg]:w-5"
 			{...restProps}

--- a/src/lib/components/ui/command/command-list.svelte
+++ b/src/lib/components/ui/command/command-list.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <CommandPrimitive.List
-	class={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+	class={cn("max-h-[40vh] sm:max-h-[300px] overflow-y-auto overflow-x-hidden overscroll-contain", className)}
 	{...restProps}
 	bind:ref
 />

--- a/src/lib/components/ui/command/command-list.svelte
+++ b/src/lib/components/ui/command/command-list.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <CommandPrimitive.List
-	class={cn("max-h-[40vh] sm:max-h-[300px] overflow-y-auto overflow-x-hidden overscroll-contain", className)}
+	class={cn("max-h-[40vh] sm:max-h-[300px] overflow-y-auto overflow-x-hidden overscroll-contain touch-pan-y", className)}
 	{...restProps}
 	bind:ref
 />

--- a/src/lib/components/ui/command/command-list.svelte
+++ b/src/lib/components/ui/command/command-list.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <CommandPrimitive.List
-	class={cn("max-h-[40vh] sm:max-h-[300px] overflow-y-auto overflow-x-hidden overscroll-contain touch-pan-y", className)}
+	class={cn("max-h-[35dvh] sm:max-h-[300px] overflow-y-auto overflow-x-hidden overscroll-contain touch-pan-y", className)}
 	{...restProps}
 	bind:ref
 />

--- a/src/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/src/lib/components/ui/dialog/dialog-overlay.svelte
@@ -12,7 +12,7 @@
 <DialogPrimitive.Overlay
 	bind:ref
 	class={cn(
-		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/80",
+		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0  fixed inset-0 z-50 bg-black/80 touch-none",
 		className
 	)}
 	{...restProps}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -302,6 +302,7 @@
 <Command pages={allPages} />
 
 <svelte:window bind:innerWidth bind:innerHeight />
+<svelte:body class={$isCommandActive ? 'overflow-hidden touch-none sm:touch-auto' : ''} />
 
 {#if $screensaverActiveStore && $screensaver === 'crash'}
 	<CrashScreensaver />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -217,9 +217,21 @@
 		}
 		debugLog(`${$isCommandActive ? 'Opening' : 'Closing'} command window`);
 		if ($isCommandActive) {
-			document.body.classList.add('overflow-hidden', 'touch-none', 'sm:touch-auto');
+			document.body.classList.add(
+				'overflow-hidden',
+				'touch-none',
+				'sm:touch-auto',
+				'fixed',
+				'w-full'
+			);
 		} else {
-			document.body.classList.remove('overflow-hidden', 'touch-none', 'sm:touch-auto');
+			document.body.classList.remove(
+				'overflow-hidden',
+				'touch-none',
+				'sm:touch-auto',
+				'fixed',
+				'w-full'
+			);
 		}
 	});
 
@@ -312,7 +324,7 @@
 	<CrashScreensaver />
 {/if}
 
-<div class="flex h-screen w-full flex-grow flex-col">
+<div class="flex h-dvh w-full flex-grow flex-col">
 	<div class="w-fixed w-full p-6 sm:px-16 print:hidden">
 		<div class="sticky top-0 h-full w-full">
 			<Header pages={bookmarks} />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -316,7 +316,7 @@
 
 	<main
 		class={cn(
-			`inset-0 h-max max-h-screen w-full flex-grow overflow-y-auto ${isFullWidth ? 'p-0' : 'py-4 sm:px-16'} print:max-h-none`,
+			`inset-0 h-max max-h-screen w-full flex-grow ${$isCommandActive ? 'overflow-hidden' : 'overflow-y-auto'} ${isFullWidth ? 'p-0' : 'py-4 sm:px-16'} print:max-h-none`,
 			`theme-${$theme}`
 		)}
 		style={bgStyle}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -216,6 +216,11 @@
 			// handleMouseMove({ clientX: innerWidth / 2, clientY: -100, timeout: 0 } as MouseEvent & { timeout: number })
 		}
 		debugLog(`${$isCommandActive ? 'Opening' : 'Closing'} command window`);
+		if ($isCommandActive) {
+			document.body.classList.add('overflow-hidden', 'touch-none', 'sm:touch-auto');
+		} else {
+			document.body.classList.remove('overflow-hidden', 'touch-none', 'sm:touch-auto');
+		}
 	});
 
 	let isLightMode = $derived($mode === 'light');
@@ -302,7 +307,6 @@
 <Command pages={allPages} />
 
 <svelte:window bind:innerWidth bind:innerHeight />
-<svelte:body class={$isCommandActive ? 'overflow-hidden touch-none sm:touch-auto' : ''} />
 
 {#if $screensaverActiveStore && $screensaver === 'crash'}
 	<CrashScreensaver />


### PR DESCRIPTION
This PR improves the mobile user experience for the command palette. When the command palette is open, the background page scroll is now locked, and the command list itself is scrollable even when the on-screen keyboard is active. The dialog has also been repositioned to avoid being obscured by the keyboard on smaller screens.

---
*PR created automatically by Jules for task [18423688585948938149](https://jules.google.com/task/18423688585948938149) started by @dnnsmnstrr*