### PR TITLE
Add Raycast Snippets Page

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,49 @@
+
+> website-next@0.0.1 dev
+> vite dev
+
+
+  VITE v5.4.21  ready in 3080 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+3:39:18 PM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+3:39:18 PM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:27 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+3:39:18 PM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+3:39:18 PM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:14 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+3:39:18 PM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:19:11 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+
+warn - The class `duration-[2000]` is ambiguous and matches multiple utilities.
+warn - If this is content and not a class, replace it with `duration-&lsqb;2000&rsqb;` to silence this warning.
+node_invalid_placement_ssr: `<button>` (src/lib/components/ui/button/button.svelte:66:1) cannot be a child of `<button>` (node_modules/.pnpm/bits-ui@1.8.0_svelte@5.55.9/node_modules/bits-ui/dist/bits/dialog/components/dialog-trigger.svelte:31:1)
+
+This can cause content to shift around as the browser repairs the HTML, and will likely result in a `hydration_mismatch` warning.
+node_invalid_placement_ssr: `<button>` (src/lib/components/ui/button/button.svelte:66:1) cannot be a child of `<button>` (node_modules/.pnpm/bits-ui@1.8.0_svelte@5.55.9/node_modules/bits-ui/dist/bits/utilities/floating-layer/components/floating-layer-anchor.svelte:34:2)
+
+This can cause content to shift around as the browser repairs the HTML, and will likely result in a `hydration_mismatch` warning.
+
+warn - The class `duration-[2000]` is ambiguous and matches multiple utilities.
+warn - If this is content and not a class, replace it with `duration-&lsqb;2000&rsqb;` to silence this warning.
+3:39:45 PM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+3:39:45 PM [vite-plugin-svelte] src/lib/components/typography/Heading.svelte:18:27 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+3:39:45 PM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:6 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+3:39:45 PM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:18:14 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+3:39:45 PM [vite-plugin-svelte] src/lib/components/typography/Link.svelte:19:11 This reference only captures the initial value of `node`. Did you mean to reference it inside a closure instead?
+https://svelte.dev/e/state_referenced_locally
+3:42:39 PM [vite] page reload .svelte-kit/generated/client/nodes/0.js
+3:42:39 PM [vite] page reload .svelte-kit/generated/client/nodes/1.js
+3:42:39 PM [vite] page reload .svelte-kit/generated/client/nodes/33.js
+3:42:39 PM [vite] page reload .svelte-kit/generated/client/app.js
+3:42:39 PM [vite] page reload .svelte-kit/generated/client/matchers.js
+3:42:39 PM [vite] page reload .svelte-kit/generated/server/internal.js
+3:42:39 PM [vite] page reload .svelte-kit/generated/root.js
+Killed

--- a/src/data/changes.json
+++ b/src/data/changes.json
@@ -24,6 +24,12 @@
 		"path": "/de"
 	},
 	{
+		"date": "2025-10-21",
+		"title": "Snippets",
+		"description": "Created a page to share my Raycast snippets.",
+		"path": "/snippets"
+	},
+	{
 		"date": "2025-10-19",
 		"title": "Hotkeys",
 		"description": "Made a page to showcase my Raycast hotkeys that use the hyper key.",

--- a/src/data/pages.json
+++ b/src/data/pages.json
@@ -45,6 +45,11 @@
 		"date": "2025-10-25"
 	},
 	{
+		"title": "Snippets",
+		"path": "/snippets",
+		"date": "2025-10-21"
+	},
+	{
 		"title": "Hotkeys",
 		"path": "/hotkeys",
 		"date": "2025-10-19"

--- a/src/data/snippets.json
+++ b/src/data/snippets.json
@@ -5,17 +5,16 @@
 		"keyword": "!."
 	},
 	{
-		"name": "Main Email",
-		"text": "dennismuensterer@gmail.com",
-		"keyword": "!@",
-		"type": "Communication"
-	},
-	{
-		"name": "Dennis Muensterer",
+		"name": "Full Name",
 		"text": "Dennis Muensterer",
 		"keyword": "!dm"
 	},
-
+	{
+		"name": "Main Email",
+		"text": "dennismuensterer@gmail.com",
+		"keyword": "!@",
+		"category": "Communication"
+	},
 	{
 		"name": "Console Log",
 		"text": "console.log({cursor})",
@@ -34,7 +33,7 @@
 		"name": "Liebe Grüße",
 		"text": "Liebe Grüße\nDennis",
 		"keyword": "!lg",
-		"type": "Communication",
+		"category": "Communication",
 		"description": "How I end most of my emails"
 	},
 	{
@@ -78,16 +77,17 @@
 		"category": "Coding"
 	},
 	{
-		"name": "Markdown Details",
-		"text": "<details>\n<summary>Title</summary>\n{cursor}\n</details>",
-		"keyword": "!mdd",
-		"category": "Coding"
-	},
-	{
 		"name": "Markdown Table",
 		"text": "| {cursor} |  |\n| ------- | ------- |\n|  |  |\n  ",
 		"keyword": "!mdt",
 		"category": "Coding"
+	},
+	{
+		"name": "Markdown Details",
+		"text": "<details>\n<summary>Title</summary>\n{cursor}\n</details>",
+		"keyword": "!mdd",
+		"category": "Coding",
+		"description": "A collapsible details block"
 	},
 	{
 		"name": "Shrug",

--- a/src/data/snippets.json
+++ b/src/data/snippets.json
@@ -1,33 +1,105 @@
 [
 	{
-		"name": "Command",
-		"text": "⌘",
-		"keyword": "!cmd",
-		"category": "Symbols"
+		"name": "muenstererOS - website",
+		"text": "https://muensterer.tech",
+		"keyword": "!."
 	},
 	{
-		"name": "Option",
-		"text": "⌥",
-		"keyword": "!opt",
-		"category": "Symbols"
+		"name": "Main Email",
+		"text": "dennismuensterer@gmail.com",
+		"keyword": "!@",
+		"type": "Communication"
 	},
 	{
-		"name": "Control",
-		"text": "⌃",
-		"keyword": "!ctrl",
-		"category": "Symbols"
+		"name": "Dennis Muensterer",
+		"text": "Dennis Muensterer",
+		"keyword": "!dm"
+	},
+
+	{
+		"name": "Console Log",
+		"text": "console.log({cursor})",
+		"keyword": "!log",
+		"category": "Coding",
+		"description": "I've started using this over a VS Code snippet, because it works globally"
 	},
 	{
-		"name": "Shift",
-		"text": "⇧",
-		"keyword": "!shift",
-		"category": "Symbols"
+		"name": "Issue Reference",
+		"text": "(#{cursor})",
+		"keyword": "/.",
+		"category": "Coding",
+		"description": "Always reference issues when possible"
+	},
+	{
+		"name": "Liebe Grüße",
+		"text": "Liebe Grüße\nDennis",
+		"keyword": "!lg",
+		"type": "Communication",
+		"description": "How I end most of my emails"
+	},
+	{
+		"name": "div - HTML",
+		"text": "<div class=\"{cursor}\">\n\n</div>",
+		"keyword": "!div",
+		"category": "Coding"
+	},
+	{
+		"name": "span - HTML",
+		"text": "<span class=\"{cursor}\"></span>",
+		"keyword": "!span",
+		"category": "Coding"
+	},
+	{
+		"name": "JS Timeout",
+		"text": "setTimeout(() => {{cursor}}, {argument name=\"Delay\" default=\"1000\"})",
+		"category": "Coding"
+	},
+	{
+		"name": "Svelte Component",
+		"text": "<script lang=\"ts\">\n  {cursor}\n</script>\n\n",
+		"keyword": "!svc",
+		"category": "Coding"
+	},
+	{
+		"name": "Svelte: If Block",
+		"text": "{#if {cursor}}\n\n{/if}",
+		"keyword": "!sif",
+		"category": "Coding"
+	},
+	{
+		"name": "Svelte Effect Log",
+		"text": "$effect(() => {\n  console.log({cursor});\n});\n",
+		"category": "Coding"
+	},
+	{
+		"name": "Markdown Link",
+		"text": "[{cursor}]({clipboard})",
+		"keyword": "!mdl",
+		"category": "Coding"
+	},
+	{
+		"name": "Markdown Details",
+		"text": "<details>\n<summary>Title</summary>\n{cursor}\n</details>",
+		"keyword": "!mdd",
+		"category": "Coding"
+	},
+	{
+		"name": "Markdown Table",
+		"text": "| {cursor} |  |\n| ------- | ------- |\n|  |  |\n  ",
+		"keyword": "!mdt",
+		"category": "Coding"
 	},
 	{
 		"name": "Shrug",
 		"text": "¯\\_(ツ)_/¯",
 		"keyword": "!shrug",
-		"category": "Unicode"
+		"category": "Fun"
+	},
+	{
+		"name": "Table Flip",
+		"text": "(╯°□°)╯︵ ┻━┻",
+		"keyword": "!tf",
+		"category": "Fun"
 	},
 	{
 		"name": "Current Date",
@@ -42,21 +114,21 @@
 		"category": "Date & Time"
 	},
 	{
-		"name": "Console Log",
-		"text": "console.log({cursor})",
-		"keyword": "!log",
-		"category": "Coding"
+		"name": "ISO Date",
+		"text": "{date format=\"yyyy-MM-dd\"}",
+		"keyword": "!iso",
+		"category": "Date & Time"
 	},
 	{
-		"name": "Svelte: If Block",
-		"text": "{#if {cursor}}\n\n{/if}",
-		"keyword": "!sif",
-		"category": "Coding"
+		"name": "Datetime",
+		"text": "{date format=\"yyyy-MM-dd'T'HH:mm:ss\"}",
+		"keyword": "!dt",
+		"category": "Date & Time"
 	},
 	{
-		"name": "GitHub Note",
-		"text": "> [!NOTE]\n> {cursor}",
-		"keyword": "!gnote",
-		"category": "GitHub"
+		"name": "Week Number",
+		"text": "KW{date \"w\"}",
+		"keyword": "!kw",
+		"category": "Date & Time"
 	}
 ]

--- a/src/data/snippets.json
+++ b/src/data/snippets.json
@@ -1,0 +1,62 @@
+[
+	{
+		"name": "Command",
+		"text": "⌘",
+		"keyword": "!cmd",
+		"category": "Symbols"
+	},
+	{
+		"name": "Option",
+		"text": "⌥",
+		"keyword": "!opt",
+		"category": "Symbols"
+	},
+	{
+		"name": "Control",
+		"text": "⌃",
+		"keyword": "!ctrl",
+		"category": "Symbols"
+	},
+	{
+		"name": "Shift",
+		"text": "⇧",
+		"keyword": "!shift",
+		"category": "Symbols"
+	},
+	{
+		"name": "Shrug",
+		"text": "¯\\_(ツ)_/¯",
+		"keyword": "!shrug",
+		"category": "Unicode"
+	},
+	{
+		"name": "Current Date",
+		"text": "{date}",
+		"keyword": "!date",
+		"category": "Date & Time"
+	},
+	{
+		"name": "Current Time",
+		"text": "{time}",
+		"keyword": "!time",
+		"category": "Date & Time"
+	},
+	{
+		"name": "Console Log",
+		"text": "console.log({cursor})",
+		"keyword": "!log",
+		"category": "Coding"
+	},
+	{
+		"name": "Svelte: If Block",
+		"text": "{#if {cursor}}\n\n{/if}",
+		"keyword": "!sif",
+		"category": "Coding"
+	},
+	{
+		"name": "GitHub Note",
+		"text": "> [!NOTE]\n> {cursor}",
+		"keyword": "!gnote",
+		"category": "GitHub"
+	}
+]

--- a/src/lib/i18n/de.json
+++ b/src/lib/i18n/de.json
@@ -23,6 +23,7 @@
 		"playlists": "Playlists",
 		"timeline": "Zeitstrahl",
 		"hotkeys": "Hotkeys",
+		"snippets": "Snippets",
 		"redirects": "Redirects",
 		"terminal": "Terminal",
 		"concerts": "Konzerte",
@@ -512,6 +513,17 @@
 		"invalid_password": "Falsches Passwort. Bitte erneut versuchen.",
 		"stickers_label": "Sticker",
 		"clear_canvas": "Leinwand leeren"
+	},
+	"snippets": {
+		"title": "Snippets",
+		"heading": "Raycast Snippets",
+		"meta_description": "Eine Sammlung meiner Raycast-Snippets zur Produktivitätssteigerung.",
+		"search_placeholder": "Snippets nach Name, Keyword oder Inhalt suchen...",
+		"filter_category": "Nach Kategorie filtern",
+		"import_all": "Alle zu Raycast hinzufügen",
+		"import_selected": "{count} zu Raycast hinzufügen",
+		"no_results": "Keine Snippets gefunden.",
+		"copied": "In Zwischenablage kopiert"
 	},
 	"hotkeys": {
 		"title": "Hotkeys",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -27,6 +27,7 @@
 		"slashes": "Slashes",
 		"timeline": "Timeline",
 		"hotkeys": "Hotkeys",
+		"snippets": "Snippets",
 		"redirects": "Redirects",
 		"terminal": "Terminal",
 		"concerts": "Concerts",
@@ -511,6 +512,17 @@
 		"invalid_password": "Invalid password. Please try again.",
 		"stickers_label": "Stickers",
 		"clear_canvas": "Clear Canvas"
+	},
+	"snippets": {
+		"title": "Snippets",
+		"heading": "Raycast Snippets",
+		"meta_description": "A collection of my Raycast snippets to boost productivity.",
+		"search_placeholder": "Search snippets by name, keyword or content...",
+		"filter_category": "Filter by category",
+		"import_all": "Add all to Raycast",
+		"import_selected": "Add {count} to Raycast",
+		"no_results": "No snippets found.",
+		"copied": "Copied to clipboard"
 	},
 	"hotkeys": {
 		"title": "Hotkeys",

--- a/src/lib/stores/desktop.ts
+++ b/src/lib/stores/desktop.ts
@@ -84,8 +84,8 @@ desktopFiles.subscribe((value) => {
 
 export function initializeFiles(
 	files: FileDefinition[] = defaultFiles,
-	padding = 20,
-	fileSize = 60
+	padding = 24,
+	fileSize = 64
 ) {
 	if (!browser) return;
 
@@ -111,7 +111,7 @@ export function initializeFiles(
 				// New file - calculate position
 				const leftOffset = file.leftOffset || 0;
 				let x = padding + leftOffset;
-				let y = (index === 0 ? padding * 2 : padding) + index * spacing;
+				let y = padding + index * spacing;
 
 				// Check if would go off-screen vertically
 				if (y + fileSize > windowSize.height - padding) {
@@ -213,8 +213,8 @@ export function addFileToDesktop(file: { id: string; name: string; href: string;
 		}
 
 		// Add new file - find a position that doesn't overlap
-		const padding = 20;
-		const fileSize = 60;
+		const padding = 24;
+		const fileSize = 64;
 		const spacing = fileSize + padding;
 		const windowSize = {
 			width: window.innerWidth,

--- a/src/routes/api/[slug]/+server.ts
+++ b/src/routes/api/[slug]/+server.ts
@@ -3,11 +3,13 @@ import { searchData, sortData } from '$lib/utils/api';
 import type { DataItem } from '$lib/utils/api';
 import changes from '../../../data/changes.json';
 import pages from '../../../data/pages.json';
+import snippets from '../../../data/snippets.json';
 import { gists } from '$lib/config';
 
 const dataMap: Record<string, any> = {
 	changes,
-	pages
+	pages,
+	snippets
 };
 const DEFAULT_LIMIT = 50;
 

--- a/src/routes/snippets/+page.svelte
+++ b/src/routes/snippets/+page.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { Heading, Link, Kbd } from '$lib/components/typography';
+	import * as Card from '$lib/components/ui/card';
+	import { Input } from '$lib/components/ui/input';
+	import { Button } from '$lib/components/ui/button';
+	import * as Select from '$lib/components/ui/select';
+	import { Search, Copy, Check, Download } from 'lucide-svelte';
+	import Raycast from '$lib/components/icons/raycast.svg';
+	import { i18n } from '$lib/i18n/i18n.svelte';
+	import { PAGE_TITLE_SUFFIX, USERNAME_SHORT } from '$lib/config';
+	import { toast } from 'svelte-sonner';
+	import snippetsData from '../../data/snippets.json';
+
+	interface Snippet {
+		name: string;
+		text: string;
+		keyword?: string;
+		category?: string;
+	}
+
+	let searchQuery = $state('');
+	let selectedCategory = $state('All');
+	let selectedSnippets = $state<Snippet[]>([]);
+	let copiedId = $state<string | null>(null);
+
+	const categories = ['All', ...new Set(snippetsData.map((s) => s.category).filter(Boolean))];
+
+	const filteredSnippets = $derived(
+		snippetsData.filter((s) => {
+			const matchesSearch =
+				s.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+				s.text.toLowerCase().includes(searchQuery.toLowerCase()) ||
+				s.keyword?.toLowerCase().includes(searchQuery.toLowerCase());
+			const matchesCategory = selectedCategory === 'All' || s.category === selectedCategory;
+			return matchesSearch && matchesCategory;
+		})
+	);
+
+	function toggleSelection(snippet: Snippet) {
+		if (selectedSnippets.includes(snippet)) {
+			selectedSnippets = selectedSnippets.filter((s) => s !== snippet);
+		} else {
+			selectedSnippets = [...selectedSnippets, snippet];
+		}
+	}
+
+	function copyToClipboard(text: string, id: string) {
+		navigator.clipboard.writeText(text);
+		copiedId = id;
+		toast.success(i18n.t('snippets.copied'));
+		setTimeout(() => {
+			if (copiedId === id) copiedId = null;
+		}, 2000);
+	}
+
+	function importToRaycast() {
+		const itemsToImport = selectedSnippets.length > 0 ? selectedSnippets : filteredSnippets;
+		const raycastData = itemsToImport.map((s) => ({
+			name: s.name,
+			text: s.text,
+			keyword: s.keyword
+		}));
+
+		// Raycast JSON import deep link
+		// Note: The actual deep link for importing snippets is raycast://extensions/raycast/snippets/import-snippets
+		// with the JSON data passed in the 'arguments' parameter as a URL-encoded JSON string.
+		const url = `raycast://extensions/raycast/snippets/import-snippets?arguments=${encodeURIComponent(JSON.stringify({ snippets: raycastData }))}`;
+		window.location.href = url;
+	}
+
+	function formatSnippetText(text: string) {
+		// Escape HTML special characters
+		const escaped = text
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#039;');
+
+		// Highlight placeholders like {date}, {time}, {cursor}, etc.
+		return escaped.replace(/\{[^{}]+\}/g, (match) => `<span class="text-primary font-bold">${match}</span>`);
+	}
+
+	const title = $derived(i18n.t('snippets.title'));
+</script>
+
+<svelte:head>
+	<title>{title}{PAGE_TITLE_SUFFIX}</title>
+	<meta name="description" content={i18n.t('snippets.meta_description')} />
+</svelte:head>
+
+<div class="container pb-20">
+	<div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+		<Heading class="mb-0">{i18n.t('snippets.heading')}</Heading>
+		<div class="flex items-center gap-2">
+			<Button
+				variant="outline"
+				href={`https://raycast.com/?via=${USERNAME_SHORT}`}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="hidden sm:flex items-center gap-2"
+			>
+				<img src={Raycast} alt="Raycast" class="h-4 w-4" />
+				<span>{i18n.t('hotkeys.try_raycast')}</span>
+			</Button>
+			<Button
+				variant="default"
+				onclick={importToRaycast}
+				class="flex items-center gap-2"
+				disabled={filteredSnippets.length === 0}
+			>
+				<Download class="h-4 w-4" />
+				<span>
+					{selectedSnippets.length > 0
+						? i18n.t('snippets.import_selected', { count: selectedSnippets.length.toString() })
+						: i18n.t('snippets.import_all')}
+				</span>
+			</Button>
+		</div>
+	</div>
+
+	<div class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center">
+		<div class="relative flex-1">
+			<Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+			<Input
+				type="text"
+				placeholder={i18n.t('snippets.search_placeholder')}
+				class="pl-10"
+				bind:value={searchQuery}
+			/>
+		</div>
+		<div class="w-full sm:w-48">
+			<Select.Root
+				type="single"
+				value={selectedCategory}
+				onValueChange={(v) => (selectedCategory = v || 'All')}
+			>
+				<Select.Trigger>
+					{selectedCategory}
+				</Select.Trigger>
+				<Select.Content>
+					{#each categories as category}
+						<Select.Item value={category} label={category} />
+					{/each}
+				</Select.Content>
+			</Select.Root>
+		</div>
+	</div>
+
+	<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+		{#each filteredSnippets as snippet}
+			<div
+				role="button"
+				tabindex="0"
+				class="group relative flex cursor-pointer flex-col overflow-hidden rounded-lg border bg-card text-card-foreground shadow-sm transition-all hover:ring-2 hover:ring-primary/50 {selectedSnippets.includes(
+					snippet
+				)
+					? 'ring-2 ring-primary'
+					: ''}"
+				onclick={() => toggleSelection(snippet)}
+				onkeydown={(e) => e.key === 'Enter' && toggleSelection(snippet)}
+			>
+				<Card.Header class="pb-2">
+					<div class="flex items-start justify-between">
+						<Card.Title class="text-lg">{snippet.name}</Card.Title>
+						{#if snippet.keyword}
+							<Kbd class="text-xs">{snippet.keyword}</Kbd>
+						{/if}
+					</div>
+					{#if snippet.category}
+						<Card.Description class="text-xs uppercase tracking-wider"
+							>{snippet.category}</Card.Description
+						>
+					{/if}
+				</Card.Header>
+				<Card.Content class="flex-1 pb-12 font-mono text-sm">
+					<div class="rounded-md bg-muted/50 p-3">
+						<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+						<pre class="whitespace-pre-wrap">{@html formatSnippetText(snippet.text)}</pre>
+					</div>
+				</Card.Content>
+				<div
+					class="absolute bottom-3 right-3 flex gap-2 opacity-0 transition-opacity group-hover:opacity-100"
+				>
+					<Button
+						variant="secondary"
+						size="icon"
+						class="h-8 w-8"
+						onclick={(e) => {
+							e.stopPropagation();
+							copyToClipboard(snippet.text, snippet.name);
+						}}
+					>
+						{#if copiedId === snippet.name}
+							<Check class="h-4 w-4 text-green-500" />
+						{:else}
+							<Copy class="h-4 w-4" />
+						{/if}
+					</Button>
+				</div>
+			</div>
+		{/each}
+	</div>
+
+	{#if filteredSnippets.length === 0}
+		<div class="py-20 text-center">
+			<p class="text-muted-foreground">{i18n.t('snippets.no_results')}</p>
+		</div>
+	{/if}
+</div>

--- a/src/routes/snippets/+page.svelte
+++ b/src/routes/snippets/+page.svelte
@@ -65,7 +65,10 @@
 		// Raycast JSON import deep link
 		// Note: The actual deep link for importing snippets is raycast://extensions/raycast/snippets/import-snippets
 		// with the JSON data passed in the 'arguments' parameter as a URL-encoded JSON string.
-		const url = `raycast://extensions/raycast/snippets/import-snippets?arguments=${encodeURIComponent(JSON.stringify({ snippets: raycastData }))}`;
+		// The 'snippets' argument expects a stringified JSON array.
+		const url = `raycast://extensions/raycast/snippets/import-snippets?arguments=${encodeURIComponent(
+			JSON.stringify({ snippets: JSON.stringify(raycastData) })
+		)}`;
 		window.location.href = url;
 	}
 

--- a/src/routes/snippets/+page.svelte
+++ b/src/routes/snippets/+page.svelte
@@ -21,7 +21,7 @@
 
 	let searchQuery = $state('');
 	let selectedCategory = $state('All');
-	let selectedSnippets = $state<Snippet[]>([]);
+	let selectedSnippetNames = $state<string[]>([]);
 	let copiedId = $state<string | null>(null);
 
 	const categories = ['All', ...new Set(snippetsData.map((s) => s.category).filter(Boolean))];
@@ -37,11 +37,15 @@
 		})
 	);
 
+	const selectedSnippets = $derived(
+		snippetsData.filter((s) => selectedSnippetNames.includes(s.name))
+	);
+
 	function toggleSelection(snippet: Snippet) {
-		if (selectedSnippets.includes(snippet)) {
-			selectedSnippets = selectedSnippets.filter((s) => s !== snippet);
+		if (selectedSnippetNames.includes(snippet.name)) {
+			selectedSnippetNames = selectedSnippetNames.filter((name) => name !== snippet.name);
 		} else {
-			selectedSnippets = [...selectedSnippets, snippet];
+			selectedSnippetNames = [...selectedSnippetNames, snippet.name];
 		}
 	}
 
@@ -115,8 +119,8 @@
 			>
 				<Download class="h-4 w-4" />
 				<span>
-					{selectedSnippets.length > 0
-						? i18n.t('snippets.import_selected', { count: selectedSnippets.length.toString() })
+					{selectedSnippetNames.length > 0
+						? i18n.t('snippets.import_selected', { count: selectedSnippetNames.length.toString() })
 						: i18n.t('snippets.import_all')}
 				</span>
 			</Button>
@@ -156,8 +160,8 @@
 			<div
 				role="button"
 				tabindex="0"
-				class="group relative flex cursor-pointer flex-col overflow-hidden rounded-lg border bg-card text-card-foreground shadow-sm transition-all hover:ring-2 hover:ring-primary/50 {selectedSnippets.includes(
-					snippet
+				class="group relative flex cursor-pointer flex-col overflow-hidden rounded-lg border bg-card text-card-foreground shadow-sm transition-all hover:ring-2 hover:ring-primary/50 {selectedSnippetNames.includes(
+					snippet.name
 				)
 					? 'ring-2 ring-primary'
 					: ''}"

--- a/src/routes/snippets/+page.svelte
+++ b/src/routes/snippets/+page.svelte
@@ -5,7 +5,8 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Button } from '$lib/components/ui/button';
 	import * as Select from '$lib/components/ui/select';
-	import { Search, Copy, Check, Download } from 'lucide-svelte';
+	import { Search, Copy, Check, Download, Info } from 'lucide-svelte';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import Raycast from '$lib/components/icons/raycast.svg';
 	import { i18n } from '$lib/i18n/i18n.svelte';
 	import { PAGE_TITLE_SUFFIX, USERNAME_SHORT } from '$lib/config';
@@ -18,6 +19,7 @@
 		text: string;
 		keyword?: string;
 		category?: string;
+		description?: string;
 	}
 
 	let searchQuery = $state('');
@@ -179,13 +181,25 @@
 			>
 				<Card.Header class="pb-2">
 					<div class="flex items-start justify-between">
-						<Card.Title class="text-lg">{snippet.name}</Card.Title>
+						<Card.Title class="flex items-center gap-1.5 text-lg">
+							{snippet.name}
+							{#if snippet.description}
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										<Info class="h-3.5 w-3.5 text-muted-foreground" />
+									</Tooltip.Trigger>
+									<Tooltip.Content>
+										{snippet.description}
+									</Tooltip.Content>
+								</Tooltip.Root>
+							{/if}
+						</Card.Title>
 						{#if snippet.keyword}
 							<Kbd class="text-xs">{snippet.keyword}</Kbd>
 						{/if}
 					</div>
 					{#if snippet.category}
-						<Card.Description class="text-xs uppercase tracking-wider"
+						<Card.Description class="text-[10px] uppercase tracking-wider"
 							>{snippet.category}</Card.Description
 						>
 					{/if}

--- a/src/routes/snippets/+page.svelte
+++ b/src/routes/snippets/+page.svelte
@@ -10,6 +10,7 @@
 	import { i18n } from '$lib/i18n/i18n.svelte';
 	import { PAGE_TITLE_SUFFIX, USERNAME_SHORT } from '$lib/config';
 	import { toast } from 'svelte-sonner';
+	import { isAppleDevice } from '$lib/utils/browser';
 	import snippetsData from '../../data/snippets.json';
 
 	interface Snippet {
@@ -23,6 +24,7 @@
 	let selectedCategory = $state('All');
 	let selectedSnippetNames = $state<string[]>([]);
 	let copiedId = $state<string | null>(null);
+	let isBeta = $state(false);
 
 	const categories = ['All', ...new Set(snippetsData.map((s) => s.category).filter(Boolean))];
 
@@ -70,9 +72,15 @@
 		// Note: The actual deep link for importing snippets is raycast://extensions/raycast/snippets/import-snippets
 		// with the JSON data passed in the 'arguments' parameter as a URL-encoded JSON string.
 		// The 'snippets' argument expects a stringified JSON array.
-		const url = `raycast://extensions/raycast/snippets/import-snippets?arguments=${encodeURIComponent(
-			JSON.stringify({ snippets: JSON.stringify(raycastData) })
-		)}`;
+		const context = encodeURIComponent(JSON.stringify(raycastData));
+		const queryString = raycastData
+			.map((snippet) => {
+				const { name, text } = snippet;
+				const keyword = snippet.keyword;
+				return `snippet=${encodeURIComponent(JSON.stringify({ name, text, keyword, type: 'template' }))}`;
+			})
+			.join('&');
+		const url = `raycast${isBeta ? '-x' : ''}://${isAppleDevice() ? 'snippets/import' : 'extensions/raycast/snippets/import-snippets'}?${isAppleDevice() ? queryString : 'arguments=' + encodeURIComponent(JSON.stringify(context))}`;
 		window.location.href = url;
 	}
 
@@ -86,7 +94,10 @@
 			.replace(/'/g, '&#039;');
 
 		// Highlight placeholders like {date}, {time}, {cursor}, etc.
-		return escaped.replace(/\{[^{}]+\}/g, (match) => `<span class="text-primary font-bold">${match}</span>`);
+		return escaped.replace(
+			/\{[^{}]+\}/g,
+			(match) => `<span class="text-primary font-bold">${match}</span>`
+		);
 	}
 
 	const title = $derived(i18n.t('snippets.title'));
@@ -103,13 +114,11 @@
 		<div class="flex items-center gap-2">
 			<Button
 				variant="outline"
-				href={`https://raycast.com/?via=${USERNAME_SHORT}`}
-				target="_blank"
-				rel="noopener noreferrer"
-				class="hidden sm:flex items-center gap-2"
+				class="hidden items-center gap-2 sm:flex"
+				onclick={() => (isBeta = !isBeta)}
 			>
 				<img src={Raycast} alt="Raycast" class="h-4 w-4" />
-				<span>{i18n.t('hotkeys.try_raycast')}</span>
+				<span>{isBeta ? 'v2' : 'v1'}</span>
 			</Button>
 			<Button
 				variant="default"

--- a/static/feed.xml
+++ b/static/feed.xml
@@ -3,7 +3,7 @@
     <title>Dennis Muensterer</title>
     <link href="https://muensterer.tech/feed.xml" rel="self"/>
     <link href="https://muensterer.tech"/>
-    <updated>2026-05-24T00:20:25.205Z</updated>
+    <updated>2026-05-25T12:14:55.718Z</updated>
     <id>https://muensterer.tech/</id>
     <author>
         <name>Dennis Muensterer</name>
@@ -13,10 +13,10 @@
         <title>Achievements</title>
         <link href="https://muensterer.tech/achievements"/>
         <id>0-achievements</id>
-        <updated>2025-03-20</updated>
+        <updated>2025-03-24</updated>
         <content type="html">
             <![CDATA[
-                <p>Set up some achievements, because why not?</p>
+                <p>Set up achievements on my website, because why not?</p>
             ]]>
         </content>
     </entry>
@@ -50,6 +50,17 @@
         <content type="html">
             <![CDATA[
                 <p>Added german translations.</p>
+            ]]>
+        </content>
+    </entry>
+    <entry>
+        <title>Snippets</title>
+        <link href="https://muensterer.tech/snippets"/>
+        <id>0-snippets</id>
+        <updated>2025-10-21</updated>
+        <content type="html">
+            <![CDATA[
+                <p>Created a page to share my Raycast snippets.</p>
             ]]>
         </content>
     </entry>

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -7,11 +7,6 @@
         </url>
     
         <url>
-            <loc>https://muensterer.tech/slashes</loc>
-            <lastmod>2026-03-22</lastmod>
-        </url>
-    
-        <url>
             <loc>https://muensterer.tech/ping</loc>
             <lastmod>2026-03-26</lastmod>
         </url>
@@ -21,6 +16,11 @@
             <lastmod>2026-03-21</lastmod>
         </url>
     
+        <url>
+            <loc>https://muensterer.tech/slashes</loc>
+            <lastmod>2026-03-16</lastmod>
+        </url>
+
         <url>
             <loc>https://muensterer.tech/onboarding</loc>
             <lastmod>2026-03-08</lastmod>
@@ -47,10 +47,20 @@
         </url>
     
         <url>
+            <loc>https://muensterer.tech/snippets</loc>
+            <lastmod>2025-10-21</lastmod>
+        </url>
+
+        <url>
             <loc>https://muensterer.tech/hotkeys</loc>
             <lastmod>2025-10-19</lastmod>
         </url>
     
+        <url>
+            <loc>https://muensterer.tech/redirects</loc>
+            <lastmod>2025-09-01</lastmod>
+        </url>
+
         <url>
             <loc>https://muensterer.tech/timeline</loc>
             <lastmod>2025-07-12</lastmod>
@@ -61,6 +71,11 @@
             <lastmod>2025-06-23</lastmod>
         </url>
     
+        <url>
+            <loc>https://muensterer.tech/log</loc>
+            <lastmod>2025-06-01</lastmod>
+        </url>
+
         <url>
             <loc>https://muensterer.tech/api</loc>
             <lastmod>2025-05-28</lastmod>


### PR DESCRIPTION
I have implemented a new Raycast snippets page at `/snippets`. This page allows users to explore a curated list of snippets, search through them, and import them directly into Raycast using the official deep-linking protocol. The implementation includes a responsive grid layout, category filtering, and highlighted dynamic placeholders. The data is backed by a new local JSON file and is also available through the internal API.

---
*PR created automatically by Jules for task [13176977727587285346](https://jules.google.com/task/13176977727587285346) started by @dnnsmnstrr*