### PR TITLE
🛡️ Sentinel: Fix path traversal bypass in redirect utility

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,9 @@
 **Vulnerability:** Open Redirect and Path Traversal via the `restPath` parameter in the `getRedirectURL` utility.
 **Learning:** The application allowed arbitrary strings to be appended to a redirect URL via the `restPath` parameter. Attackers could use `../` to traverse out of the intended path or `//` to create a protocol-relative link to an external domain.
 **Prevention:** Always sanitize parameters that are used to build URLs for redirection. Use robust regex to remove traversal sequences and leading slashes that could be interpreted as protocol-relative.
+
+## 2025-05-23 - Path Traversal Bypass via One-Pass Sanitization
+
+**Vulnerability:** Path Traversal bypass in `getRedirectURL` via nested patterns like `....//`.
+**Learning:** A single-pass `.replace()` call can be bypassed by nesting the search pattern within itself. For example, `....//` becomes `../` after one pass of removing `../`.
+**Prevention:** Use a `while` loop to recursively apply sanitization until no more changes occur, or use more robust URL parsing logic that doesn't rely solely on string replacement.

--- a/src/lib/utils/redirect.test.ts
+++ b/src/lib/utils/redirect.test.ts
@@ -110,5 +110,19 @@ describe('redirect utils', () => {
 			expect(result).not.toContain('..\\');
 			expect(result).toBe('https://test.com/evil.com');
 		});
+
+		it('should recursively sanitize restPath to prevent bypasses', () => {
+			const redirect: Redirect = { name: 'test', url: 'https://test.com' };
+			const restPath = '....//evil.com';
+			const result = getRedirectURL(redirect, { restPath });
+			expect(result).toBe('https://test.com/evil.com');
+		});
+
+		it('should handle nested traversal patterns', () => {
+			const redirect: Redirect = { name: 'test', url: 'https://test.com' };
+			const restPath = '..//../..\\/evil.com';
+			const result = getRedirectURL(redirect, { restPath });
+			expect(result).toBe('https://test.com/evil.com');
+		});
 	});
 });

--- a/src/lib/utils/redirect.ts
+++ b/src/lib/utils/redirect.ts
@@ -43,11 +43,17 @@ export const getRedirectURL = (
 	let path = '';
 
 	// Robustly sanitize restPath to prevent path traversal and open redirects
-	// 1. Remove all occurrences of ../ (and variations like ..\ or encoded)
-	// 2. Ensure it doesn't start with / or \ to prevent protocol-relative redirects
-	const sanitizedRestPath = restPath
-		?.replace(/\.\.[/\\]/g, '') // Remove ../ and ..\
-		?.replace(/^[/\\]+/, ''); // Remove leading slashes
+	// 1. Recursively remove all occurrences of ../ (and variations like ..\ or encoded)
+	// 2. Recursively ensure it doesn't start with / or \ to prevent protocol-relative redirects
+	let sanitizedRestPath = restPath || '';
+	let previousPath: string;
+
+	do {
+		previousPath = sanitizedRestPath;
+		sanitizedRestPath = sanitizedRestPath
+			.replace(/\.\.[/\\]/g, '') // Remove ../ and ..\
+			.replace(/^[/\\]+/, ''); // Remove leading slashes
+	} while (sanitizedRestPath !== previousPath);
 
 	if (url) {
 		path = `${url}${path}${sanitizedRestPath ? `/${sanitizedRestPath}` : ''}`;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path traversal bypass in `getRedirectURL` via one-pass sanitization.
🎯 Impact: Attackers could potentially bypass the existing sanitization using patterns like `....//` to perform path traversal or open redirects.
🔧 Fix: Implemented recursive sanitization using a `do...while` loop in `src/lib/utils/redirect.ts` to ensure all traversal sequences and leading slashes are removed.
✅ Verification: Added unit tests in `src/lib/utils/redirect.test.ts` covering bypass patterns and verified with `pnpm test:unit`.

---
*PR created automatically by Jules for task [3801139709142683563](https://jules.google.com/task/3801139709142683563) started by @dnnsmnstrr*