### PR TITLE
🛡️ Sentinel: Fix sensitive token leakage in /api/export

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,9 @@
 **Vulnerability:** Path Traversal bypass in `getRedirectURL` via nested patterns like `....//`.
 **Learning:** A single-pass `.replace()` call can be bypassed by nesting the search pattern within itself. For example, `....//` becomes `../` after one pass of removing `../`.
 **Prevention:** Use a `while` loop to recursively apply sanitization until no more changes occur, or use more robust URL parsing logic that doesn't rely solely on string replacement.
+
+## 2026-06-01 - Sensitive Token Leakage via Query Parameters
+
+**Vulnerability:** Exposure of GitHub Personal Access Tokens (PAT) in the `/api/export` endpoint via the `token` query parameter.
+**Learning:** Tokens passed in query parameters are frequently leaked through browser history, server logs, and the `Referer` header. Even if the frontend prefers headers, providing a query parameter fallback invites insecure usage.
+**Prevention:** Strictly enforce the use of the `Authorization` header for sensitive tokens. Avoid supporting query parameter fallbacks for authentication in API endpoints.

--- a/src/routes/api/export/+server.ts
+++ b/src/routes/api/export/+server.ts
@@ -17,8 +17,7 @@ const staticData = {
 export async function GET({ url, request }) {
 	const includeStatic = url.searchParams.get('static') !== 'false';
 	const includeGists = url.searchParams.get('gists') !== 'false';
-	const token =
-		request.headers.get('Authorization')?.replace('Bearer ', '') || url.searchParams.get('token');
+	const token = request.headers.get('Authorization')?.replace('Bearer ', '');
 
 	const exportData: any = {
 		metadata: {


### PR DESCRIPTION
Removed the `token` query parameter from `/api/export` to prevent sensitive GitHub tokens from being logged or leaked via URL. Tokens must now be passed via the `Authorization` header.

---
*PR created automatically by Jules for task [6584338202407849242](https://jules.google.com/task/6584338202407849242) started by @dnnsmnstrr*