### PR TITLE
🛡️ Sentinel: Secure the Export API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,9 @@
 **Vulnerability:** Path Traversal bypass in `getRedirectURL` via nested patterns like `....//`.
 **Learning:** A single-pass `.replace()` call can be bypassed by nesting the search pattern within itself. For example, `....//` becomes `../` after one pass of removing `../`.
 **Prevention:** Use a `while` loop to recursively apply sanitization until no more changes occur, or use more robust URL parsing logic that doesn't rely solely on string replacement.
+
+## 2026-06-02 - Insecure Credential Handling and Broken Access Control in Export API
+
+**Vulnerability:** The `/api/export` endpoint accepted an insecure `token` query parameter and lacked owner-level authorization checks.
+**Learning:** Accepting credentials in URL parameters leads to sensitive data exposure in server logs, browser history, and proxy logs. Furthermore, simply checking for the presence of a token is insufficient for administrative actions; the token's identity must be verified against the authorized owner.
+**Prevention:** Strictly enforce the use of `Authorization` headers for sensitive tokens and perform explicit authorization checks against a known owner identity (e.g., matching the GitHub username from the `/user` endpoint) for all admin-level API routes.

--- a/src/routes/api/export/+server.ts
+++ b/src/routes/api/export/+server.ts
@@ -1,4 +1,4 @@
-import { gists } from '$lib/config';
+import { gists, USERNAME_SHORT } from '$lib/config';
 import { json } from '@sveltejs/kit';
 import buttons from '$lib/../data/buttons.json';
 import changes from '$lib/../data/changes.json';
@@ -14,11 +14,29 @@ const staticData = {
 	pages
 };
 
-export async function GET({ url, request }) {
+export async function GET({ url, request, fetch }) {
 	const includeStatic = url.searchParams.get('static') !== 'false';
 	const includeGists = url.searchParams.get('gists') !== 'false';
-	const token =
-		request.headers.get('Authorization')?.replace('Bearer ', '') || url.searchParams.get('token');
+	const authHeader = request.headers.get('Authorization');
+	const token = authHeader?.replace('Bearer ', '').replace('token ', '');
+
+	if (includeGists) {
+		if (!authHeader) {
+			return json({ error: 'Unauthorized: Gist export requires admin token' }, { status: 401 });
+		}
+
+		try {
+			const userRes = await fetch('https://api.github.com/user', {
+				headers: { Authorization: authHeader }
+			});
+			const userData = await userRes.json();
+			if (!userRes.ok || userData.login !== USERNAME_SHORT) {
+				return json({ error: 'Forbidden: Admin access required' }, { status: 403 });
+			}
+		} catch (err) {
+			return json({ error: 'Authentication failed' }, { status: 500 });
+		}
+	}
 
 	const exportData: any = {
 		metadata: {
@@ -43,11 +61,9 @@ export async function GET({ url, request }) {
 			gistEntries.map(async ([name, gist]) => {
 				const gistApiUrl = `https://api.github.com/gists/${gist.id}`;
 				const headers: Record<string, string> = {
-					Accept: 'application/vnd.github.v3+json'
+					Accept: 'application/vnd.github.v3+json',
+					Authorization: `token ${token}`
 				};
-				if (token) {
-					headers['Authorization'] = `token ${token}`;
-				}
 
 				try {
 					const response = await fetch(gistApiUrl, { headers });

--- a/src/routes/api/export/export.test.ts
+++ b/src/routes/api/export/export.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GET } from './+server';
+import { USERNAME_SHORT } from '$lib/config';
+
+describe('/api/export', () => {
+	it('returns static data without authentication if gists=false', async () => {
+		const url = new URL('http://localhost/api/export?gists=false');
+		const request = new Request(url);
+
+		const response = await GET({ url, request, fetch: vi.fn() } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.staticData).toBeDefined();
+		expect(data.gists).toBeUndefined();
+	});
+
+	it('returns 401 if gists=true and no Authorization header', async () => {
+		const url = new URL('http://localhost/api/export?gists=true');
+		const request = new Request(url);
+
+		const response = await GET({ url, request, fetch: vi.fn() } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(401);
+		expect(data.error).toContain('Unauthorized');
+	});
+
+	it('returns 403 if token belongs to wrong user', async () => {
+		const url = new URL('http://localhost/api/export?gists=true');
+		const request = new Request(url, {
+			headers: { Authorization: 'Bearer wrong_token' }
+		});
+
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: () => Promise.resolve({ login: 'attacker' })
+		});
+
+		const response = await GET({ url, request, fetch: mockFetch } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(403);
+		expect(data.error).toContain('Forbidden');
+	});
+
+	it('returns 200 if token belongs to owner', async () => {
+		const url = new URL('http://localhost/api/export?gists=true');
+		const request = new Request(url, {
+			headers: { Authorization: 'Bearer valid_token' }
+		});
+
+		const mockFetch = vi.fn().mockImplementation((url) => {
+			if (url === 'https://api.github.com/user') {
+				return Promise.resolve({
+					ok: true,
+					json: () => Promise.resolve({ login: USERNAME_SHORT })
+				});
+			}
+			if (url.startsWith('https://api.github.com/gists/')) {
+				return Promise.resolve({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							files: { 'test.json': { content: '{}' } },
+							updated_at: new Date().toISOString(),
+							html_url: 'http://gist.com',
+							history: []
+						})
+				});
+			}
+			return Promise.reject(new Error('Unknown URL'));
+		});
+
+		const response = await GET({ url, request, fetch: mockFetch } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(data.gists).toBeDefined();
+	});
+
+	it('ignores token in query parameter', async () => {
+		const url = new URL('http://localhost/api/export?gists=true&token=leaked_token');
+		const request = new Request(url);
+
+		const response = await GET({ url, request, fetch: vi.fn() } as any);
+		const data = await response.json();
+
+		expect(response.status).toBe(401); // Should still be unauthorized because query token is ignored
+	});
+});


### PR DESCRIPTION
This PR secures the `/api/export` endpoint by addressing insecure credential handling and broken access control.

### Changes:
- **Credential Security:** Removed support for the `token` query parameter. Sensitive GitHub tokens must now be provided exclusively via the `Authorization` header (`Bearer` or `token` prefix).
- **Owner Verification:** Added an explicit authorization check that validates the provided token against the GitHub API (`/user` endpoint) to ensure it belongs to the site owner (`USERNAME_SHORT`).
- **Improved Error Handling:** Introduced appropriate 401 (Unauthorized) and 403 (Forbidden) responses for failed authentication or authorization attempts.
- **Testing:** Added a new test file `src/routes/api/export/export.test.ts` to ensure the security logic works as expected and to prevent regressions.

### Verification:
- Ran `pnpm test` and verified that the new security tests pass.
- Verified that static data can still be exported without authentication when `gists=false`.
- Confirmed that gist exports require a valid admin token.

---
*PR created automatically by Jules for task [11086138185083788060](https://jules.google.com/task/11086138185083788060) started by @dnnsmnstrr*