### PR TITLE
🛡️ Sentinel: [HIGH] Fix unauthorized data export in /api/export

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,9 @@
 **Vulnerability:** Path Traversal bypass in `getRedirectURL` via nested patterns like `....//`.
 **Learning:** A single-pass `.replace()` call can be bypassed by nesting the search pattern within itself. For example, `....//` becomes `../` after one pass of removing `../`.
 **Prevention:** Use a `while` loop to recursively apply sanitization until no more changes occur, or use more robust URL parsing logic that doesn't rely solely on string replacement.
+
+## 2025-05-24 - Unauthorized Data Export and Token Leakage
+
+**Vulnerability:** The `/api/export` endpoint was accessible without authentication and supported tokens in query parameters.
+**Learning:** Utility endpoints for data export often handle sensitive content and need strict authentication. Tokens in query parameters are insecure as they leak into server logs and browser history.
+**Prevention:** Enforce the use of the `Authorization` header for sensitive endpoints. Implement server-side authorization checks (e.g., verifying the token owner against a whitelist) before proceeding with the operation.

--- a/e2e/api.test.ts
+++ b/e2e/api.test.ts
@@ -50,8 +50,8 @@ test.describe('GET /api/[slug] — generic data endpoint', () => {
 
 		test('total matches the number of entries in changes.json', async ({ request }) => {
 			const body = await getJSON(request, '/api/changes');
-			// There are 12 entries in the static changes.json file
-			expect(body.total).toBe(12);
+			// There are 14 entries in the static changes.json file
+			expect(body.total).toBe(14);
 		});
 
 		test('each item has date, title, and description fields', async ({ request }) => {
@@ -158,8 +158,8 @@ test.describe('GET /api/[slug] — generic data endpoint', () => {
 
 		test('total matches the number of entries in pages.json', async ({ request }) => {
 			const body = await getJSON(request, '/api/pages');
-			// There are 22 entries in the static pages.json file
-			expect(body.total).toBe(22);
+			// There are 27 entries in the static pages.json file
+			expect(body.total).toBe(27);
 		});
 
 		test('each item has title and path fields', async ({ request }) => {
@@ -252,8 +252,8 @@ test.describe('GET /api/status', () => {
 
 	test('pageCount matches the number of entries in pages.json', async ({ request }) => {
 		const body = await getJSON(request, '/api/status');
-		// 22 entries in pages.json
-		expect(body.pageCount).toBe(22);
+		// 27 entries in pages.json
+		expect(body.pageCount).toBe(27);
 	});
 
 	test('lastDeployment is a valid ISO 8601 date string', async ({ request }) => {
@@ -306,43 +306,26 @@ test.describe('GET /api/gists', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('GET /api/export', () => {
-	test('returns 200 with JSON', async ({ request }) => {
-		await getJSON(request, '/api/export');
+	test('returns 401 without token', async ({ request }) => {
+		const res = await request.get('/api/export');
+		expect(res.status()).toBe(401);
+		const body = await res.json();
+		expect(body.error).toContain('Unauthorized');
 	});
 
-	test('response has metadata, staticData shape', async ({ request }) => {
-		const body = await getJSON(request, '/api/export');
+	test('returns 401 without token even with parameters', async ({ request }) => {
+		const res = await request.get('/api/export?static=true&gists=true');
+		expect(res.status()).toBe(401);
+	});
 
-		expect(body.metadata).toMatchObject({
-			exportedAt: expect.any(String),
-			origin: expect.any(String),
-			options: { static: true, gists: true }
+	test('returns 403 with invalid token', async ({ request }) => {
+		// This might still fail if GitHub API is down or rate limited, but we expect 403 or 500
+		const res = await request.get('/api/export', {
+			headers: {
+				Authorization: 'token invalid_token'
+			}
 		});
-		expect(body.staticData).toBeDefined();
-	});
-
-	test('staticData contains all expected static datasets', async ({ request }) => {
-		const body = await getJSON(request, '/api/export');
-
-		for (const key of ['buttons', 'changes', 'pages', 'llms', 'network_seeds']) {
-			expect(body.staticData, `staticData.${key} should exist`).toHaveProperty(key);
-		}
-	});
-
-	test('?static=false omits staticData', async ({ request }) => {
-		const body = await getJSON(request, '/api/export?static=false');
-		expect(body.staticData).toBeUndefined();
-	});
-
-	test('?gists=false omits gists data', async ({ request }) => {
-		const body = await getJSON(request, '/api/export?gists=false');
-		expect(body.gists).toBeUndefined();
-	});
-
-	test('metadata.exportedAt is a valid ISO 8601 timestamp', async ({ request }) => {
-		const body = await getJSON(request, '/api/export');
-		expect(() => new Date(body.metadata.exportedAt)).not.toThrow();
-		expect(isNaN(new Date(body.metadata.exportedAt).getTime())).toBe(false);
+		expect([403, 500]).toContain(res.status());
 	});
 });
 

--- a/src/routes/api/export/+server.ts
+++ b/src/routes/api/export/+server.ts
@@ -1,4 +1,4 @@
-import { gists } from '$lib/config';
+import { gists, USERNAME_SHORT } from '$lib/config';
 import { json } from '@sveltejs/kit';
 import buttons from '$lib/../data/buttons.json';
 import changes from '$lib/../data/changes.json';
@@ -14,11 +14,28 @@ const staticData = {
 	pages
 };
 
-export async function GET({ url, request }) {
+export async function GET({ url, request, fetch }) {
 	const includeStatic = url.searchParams.get('static') !== 'false';
 	const includeGists = url.searchParams.get('gists') !== 'false';
-	const token =
-		request.headers.get('Authorization')?.replace('Bearer ', '') || url.searchParams.get('token');
+
+	const authHeader = request.headers.get('Authorization');
+	if (!authHeader) {
+		return json({ error: 'Unauthorized: Export requires admin token' }, { status: 401 });
+	}
+
+	try {
+		const userRes = await fetch('https://api.github.com/user', {
+			headers: { Authorization: authHeader }
+		});
+		const userData = await userRes.json();
+		if (!userRes.ok || userData.login !== USERNAME_SHORT) {
+			return json({ error: 'Forbidden: Admin access required' }, { status: 403 });
+		}
+	} catch (err) {
+		return json({ error: 'Authentication failed' }, { status: 500 });
+	}
+
+	const token = authHeader.replace('Bearer ', '').replace('token ', '');
 
 	const exportData: any = {
 		metadata: {


### PR DESCRIPTION
Identified a security risk in the `/api/export` endpoint where sensitive data could be exported without proper authentication and authorization. The endpoint also supported passing tokens via query parameters, which is an insecure practice.

I have implemented the following changes:
1.  **Authentication Enforcement**: The endpoint now strictly requires an `Authorization` header.
2.  **Authorization Check**: Added a verification step that queries the GitHub API to ensure the provided token belongs to the authorized site owner (`USERNAME_SHORT`).
3.  **Removal of Insecure Parameters**: Removed support for the `token` query parameter to prevent credentials from being logged or leaked via Referer headers.
4.  **Test Updates**: Updated the E2E test suite in `e2e/api.test.ts` to verify these new security measures. Additionally, I updated the hardcoded item counts for the changes and pages endpoints which were causing unrelated test failures.
5.  **Documentation**: Added a new entry to the Sentinel journal (`.jules/sentinel.md`) documenting the vulnerability and its prevention.

---
*PR created automatically by Jules for task [5399357153520429994](https://jules.google.com/task/5399357153520429994) started by @dnnsmnstrr*