### PR TITLE
Update contact page layout breakpoint

### DIFF
--- a/src/routes/contact/contact.svelte
+++ b/src/routes/contact/contact.svelte
@@ -41,7 +41,7 @@
 <div class="container mx-auto px-4 py-8">
 	<Heading>{i18n.t('contact.title')}</Heading>
 
-	<div class="mt-8 grid grid-cols-1 gap-12 lg:grid-cols-2">
+	<div class="mt-8 grid grid-cols-1 gap-12 md:grid-cols-2">
 		<!-- Phonebook Section -->
 		<div class="flex flex-col gap-6">
 			<div class="grid gap-4">
@@ -69,7 +69,7 @@
 		</div>
 
 		<!-- Dialer Section -->
-		<div class="flex flex-col items-center justify-start lg:sticky lg:top-24 h-fit">
+		<div class="flex flex-col items-center justify-start md:sticky md:top-24 h-fit">
 			<Dialer {codes} onMatch={handleMatch} />
 		</div>
 	</div>

--- a/src/routes/contact/dialer.svelte
+++ b/src/routes/contact/dialer.svelte
@@ -125,7 +125,7 @@
 		{#each buttons as { digit, letters }}
 			<Button
 				variant="outline"
-				class="h-16 w-16 flex flex-col items-center justify-center rounded-full p-0 pt-1"
+				class="h-16 w-16 flex flex-col items-center justify-center rounded-full p-0 pt-1 select-none"
 				onclick={() => handlePress(digit)}
 			>
 				<span class="text-xl font-bold leading-none">{digit}</span>


### PR DESCRIPTION
Adjusted the responsive breakpoint for the contact page to maintain the side-by-side layout (contact list and dialer) on medium-sized screens (>= 768px). Previously, the layout would stack on screens smaller than 1024px. The sticky behavior of the dialer was also updated to match the new grid breakpoint.

---
*PR created automatically by Jules for task [15298894135570655274](https://jules.google.com/task/15298894135570655274) started by @dnnsmnstrr*