### PR TITLE
Update contact navigation to internal page

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -65,6 +65,7 @@ export const links = {
 	applemusic: 'https://music.apple.com/profile/' + USERNAME_SHORT,
 	email: EMAIL,
 	mailto: 'mailto:' + EMAIL,
+	contact: '/contact',
 	cv: 'https://cv.muensterer.tech',
 	pages: `https://${USERNAME_SHORT}.github.io`
 } as const;

--- a/src/lib/redirects.ts
+++ b/src/lib/redirects.ts
@@ -16,7 +16,7 @@ export const redirects: Redirect[] = [
 	{
 		name: 'contact',
 		description: 'Send me an email',
-		url: links.mailto,
+		url: links.contact,
 		aliases: ['email', 'message', 'mail', '📧']
 	},
 	{

--- a/src/routes/Command.svelte
+++ b/src/routes/Command.svelte
@@ -211,7 +211,7 @@
 					debugLog($showHelp ? 'Showing' : 'Closing', 'help dialog...');
 					break;
 				case '@':
-					window.location.href = links.mailto;
+					goto(links.contact);
 					break;
 				default:
 					break;

--- a/src/routes/Menu.svelte
+++ b/src/routes/Menu.svelte
@@ -198,7 +198,7 @@
 				<Menubar.Shortcut>?</Menubar.Shortcut>
 			</Menubar.Item>
 			<Menubar.Separator />
-			<Menubar.Link href={links.mailto} target="_blank">
+			<Menubar.Link href={links.contact}>
 				{i18n.t('common.contact')}
 				<Menubar.Shortcut>@</Menubar.Shortcut>
 			</Menubar.Link>


### PR DESCRIPTION
Changed the "Contact" button in the menu bar and the `@` keyboard shortcut to navigate to the internal `/contact` page instead of opening a `mailto:` link. Also updated the corresponding redirect entry for consistency.

---
*PR created automatically by Jules for task [15819072524292654093](https://jules.google.com/task/15819072524292654093) started by @dnnsmnstrr*