### PR TITLE
Add high-resolution favicon support to OG Image Builder

### DIFF
--- a/src/lib/components/IconPicker.svelte
+++ b/src/lib/components/IconPicker.svelte
@@ -17,15 +17,18 @@
 		class?: string;
 	} = $props();
 
-	const allIconNames = Object.keys(LucideIcons)
-		.filter(
-			(key) =>
-				(typeof (LucideIcons as any)[key] === 'function' ||
-					typeof (LucideIcons as any)[key] === 'object') &&
-				/^[A-Z]/.test(key) &&
-				key !== 'createLucideIcon'
-		)
-		.sort();
+	const allIconNames = [
+		'favicon',
+		...Object.keys(LucideIcons)
+			.filter(
+				(key) =>
+					(typeof (LucideIcons as any)[key] === 'function' ||
+						typeof (LucideIcons as any)[key] === 'object') &&
+					/^[A-Z]/.test(key) &&
+					key !== 'createLucideIcon'
+			)
+			.sort()
+	];
 
 	let searchQuery = $state('');
 
@@ -55,7 +58,9 @@
 		<div class={className}>
 		<Select.Trigger class="w-full">
 			<div class="flex items-center gap-2">
-				{#if value && (LucideIcons as any)[value]}
+				{#if value === 'favicon'}
+					<img src="/images/muenstererOS.svg" alt="favicon" class="h-4 w-4" />
+				{:else if value && (LucideIcons as any)[value]}
 					{@const Icon = (LucideIcons as any)[value] as Component}
 					<Icon size={16} />
 				{/if}
@@ -71,14 +76,23 @@
 			</div>
 			<div class="overflow-y-auto">
 				{#each filteredIcons.slice(0, 100) as name}
-					{@const Icon = (LucideIcons as any)[name] as Component}
-					{#if Icon}
+					{#if name === 'favicon'}
 						<Select.Item value={name} label={name}>
 							<div class="flex items-center gap-2">
-								<Icon size={16} />
+								<img src="/images/muenstererOS.svg" alt="favicon" class="h-4 w-4" />
 								<span>{name}</span>
 							</div>
 						</Select.Item>
+					{:else}
+						{@const Icon = (LucideIcons as any)[name] as Component}
+						{#if Icon}
+							<Select.Item value={name} label={name}>
+								<div class="flex items-center gap-2">
+									<Icon size={16} />
+									<span>{name}</span>
+								</div>
+							</Select.Item>
+						{/if}
 					{/if}
 				{/each}
 				{#if filteredIcons.length > 100}

--- a/src/lib/components/OGPreview.svelte
+++ b/src/lib/components/OGPreview.svelte
@@ -88,7 +88,7 @@
 								: 'rgba(255,255,255,0.1)'}"
 						>
 							{#if isFavicon}
-								<img src="/favicon.ico" alt="Favicon" class="h-32 w-32 object-contain" />
+								<img src="/images/muenstererOS.svg" alt="Favicon" class="h-32 w-32 object-contain" />
 							{:else}
 								<Icon size={128} strokeWidth={1.5} />
 							{/if}
@@ -111,7 +111,7 @@
 			{:else}
 				<div class="flex flex-col items-center gap-6">
 					{#if isFavicon}
-						<img src="/favicon.ico" alt="Favicon" class="h-32 w-32 object-contain" />
+						<img src="/images/muenstererOS.svg" alt="Favicon" class="h-32 w-32 object-contain" />
 					{:else}
 						<Icon size={128} strokeWidth={1.5} />
 					{/if}


### PR DESCRIPTION
I have added a way to select and display the site's favicon (using the high-resolution `muenstererOS.svg` asset) in the OpenGraph image builder.

Key changes:
- **`IconPicker.svelte`**: Added a hardcoded 'favicon' option at the top of the icon list. When selected, it displays the `muenstererOS.svg` in the trigger and the dropdown.
- **`OGPreview.svelte`**: Updated the `isFavicon` logic to render `/images/muenstererOS.svg` instead of `/favicon.ico`, ensuring the icon remains sharp at large sizes in OG images.

I verified the changes by running the dev server and using a Playwright script to capture a screenshot of the OG Image Builder with the 'favicon' option selected.

---
*PR created automatically by Jules for task [15631079846843363071](https://jules.google.com/task/15631079846843363071) started by @dnnsmnstrr*