### PR TITLE
Fix blank screen in Vercel previews

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -317,8 +317,17 @@
 	const pageDescription = $derived(i18n.t(`common.description`));
 
 	const isIsolatedPage = $derived(
-		page.url.pathname.startsWith('/og-preview') || page.url.pathname.startsWith('/pap/preview')
+		page.route.id === '/og-preview' || page.route.id === '/pap/preview'
 	);
+
+	$effect(() => {
+		if (window.location.host.includes('vercel') || window.location.host.includes('test')) {
+			debugLog('Preview environment detected');
+			debugLog('Route ID:', page.route.id);
+			debugLog('Pathname:', page.url.pathname);
+			debugLog('Is isolated page:', isIsolatedPage);
+		}
+	});
 </script>
 
 <svelte:head>
@@ -348,7 +357,9 @@
 <svelte:window bind:innerWidth bind:innerHeight />
 
 {#if isIsolatedPage}
-	{@render children?.()}
+	<Tooltip.Provider>
+		{@render children?.()}
+	</Tooltip.Provider>
 {:else}
 	<Command pages={allPages} />
 

--- a/src/routes/de/+page.ts
+++ b/src/routes/de/+page.ts
@@ -1,8 +1,11 @@
 import { redirect } from '@sveltejs/kit';
+import { browser } from '$app/environment';
 
 export const load = async () => {
 	// Set the language to German
-	localStorage.setItem('language', 'de');
+	if (browser) {
+		localStorage.setItem('language', 'de');
+	}
 
 	// Redirect to home
 	throw redirect(302, '/');


### PR DESCRIPTION
Fixed a blank screen issue in Vercel preview deployments by making the isolated page logic more robust, ensuring essential context providers are present even in isolated mode, and fixing an SSR-unsafe `localStorage` call in the German redirect route. Also added environment-specific debug logging.

---
*PR created automatically by Jules for task [11396583445587033544](https://jules.google.com/task/11396583445587033544) started by @dnnsmnstrr*