### PR TITLE
Disable flashlight effect and cursor tracking on mobile

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -68,6 +68,7 @@
 	let { children }: Props = $props();
 	let innerWidth = $state(0);
 	let innerHeight = $state(0);
+	let canHover = $state(false);
 
 	const cursor = Spring.of(() => ({ x: 0, y: 0 }), {
 		stiffness: 0.05,
@@ -109,6 +110,7 @@
 
 	let timeout: ReturnType<typeof setTimeout> | undefined = undefined;
 	function handleMouseMove(event?: MouseEvent & { timeout?: number; duration?: number }) {
+		if (!canHover) return;
 		clearTimeout(timeout);
 		const largestEdge = Math.max(innerWidth, innerHeight);
 		switch (page.url.pathname) {
@@ -155,6 +157,7 @@
 	}
 
 	onMount(() => {
+		canHover = window.matchMedia('(hover: hover)').matches;
 		cursor.set({ x: innerWidth / 2, y: innerHeight / 2 });
 		if (page.url.pathname === '/') {
 			cursor.set({ x: innerWidth / 2, y: innerHeight / 3 }); // initial positioning around hero window
@@ -163,11 +166,13 @@
 			changeRadius(innerWidth * 4, innerWidth * 4, 0);
 		}
 		handleMouseMove();
-		setTimeout(() => {
-			// wait a bit before following cursor after page is loaded
-			document.addEventListener('mousemove', handleMouseMove);
-			document.addEventListener('dragover', handleMouseMove);
-		}, 1000);
+		if (canHover) {
+			setTimeout(() => {
+				// wait a bit before following cursor after page is loaded
+				document.addEventListener('mousemove', handleMouseMove);
+				document.addEventListener('dragover', handleMouseMove);
+			}, 1000);
+		}
 
 		return () => {
 			document.removeEventListener('mousemove', handleMouseMove);
@@ -370,17 +375,19 @@
 			)}
 			style={bgStyle}
 		>
-			<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-			<div
-				role="region"
-				onmousedown={() => setMaskSize(50)}
-				onmouseup={() => setMaskSize(100)}
-				class="pointer-events-none absolute inset-0 top-20 transition-[background-position] duration-100"
-				style="--tw-bg-opacity: 0.8; background-image: radial-gradient({maskWidth.current}px {maskHeight.current}px at var(--x) var(--y), transparent 0%, transparent {innerRadius.current}px, rgba({isLightMode
-					? '255, 255, 255'
-					: '0, 0, 0'}, var(--tw-bg-opacity)) {outerRadius.current}px); --x: {cursor.current
-					.x}px; --y: {cursor.current.y}px;"
-			></div>
+			{#if canHover}
+				<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+				<div
+					role="region"
+					onmousedown={() => setMaskSize(50)}
+					onmouseup={() => setMaskSize(100)}
+					class="pointer-events-none absolute inset-0 top-20 transition-[background-position] duration-100"
+					style="--tw-bg-opacity: 0.8; background-image: radial-gradient({maskWidth.current}px {maskHeight.current}px at var(--x) var(--y), transparent 0%, transparent {innerRadius.current}px, rgba({isLightMode
+						? '255, 255, 255'
+						: '0, 0, 0'}, var(--tw-bg-opacity)) {outerRadius.current}px); --x: {cursor.current
+						.x}px; --y: {cursor.current.y}px;"
+				></div>
+			{/if}
 			<Tooltip.Provider>
 				{@render children?.()}
 			</Tooltip.Provider>

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -38,15 +38,19 @@
     }
   })
   onMount(() => {
-    document.addEventListener('mousemove', handleMouseMove);
+    canHover = window.matchMedia('(hover: hover)').matches;
+    if (canHover) {
+      document.addEventListener('mousemove', handleMouseMove);
+    }
     window.addEventListener('resize', handleResize);
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('resize', handleResize);
     };
   })
-  let container: HTMLDivElement | null = null;
+  let container = $state<HTMLDivElement | null>(null);
   const basis = 'basis-full md:basis-1/2 lg:basis-1/3'
+  let canHover = $state(false);
 
 </script>
 
@@ -58,29 +62,31 @@
   }}
 >
   <Carousel.Content>
-    <Carousel.Item class="{basis} h-full">
-      <div class="p-2 sm:p-0.5 h-full">
-        <Card.Root class="min-h-[500px]">
-          <Card.Header>
-            <Card.Title>Cursor Tracking</Card.Title>
-          </Card.Header>
-          <Card.Content class="flex flex-col aspect-square border-2 border-bg rounded-lg m-2">
-            <div 
-              bind:this={container} 
-              class="flex items-center justify-center p-6 relative h-full w-full inset-0" 
-            >
-                <div 
-                class="absolute rounded-full bg-primary w-4 h-4" 
-                style="left: {Math.min(Math.max(cursor.current.x - cursorContainer.x, -16), cursorContainer.width)}px; 
-                     top: {Math.min(Math.max(cursor.current.y - cursorContainer.y * 5, 8), cursorContainer.height)}px">
-                </div>
-              x: {Math.round(cursor.current.x)}px <br>
-              y: {Math.round(cursor.current.y)}px
-            </div>
-          </Card.Content>
-        </Card.Root>
-      </div>
-    </Carousel.Item>
+    {#if canHover}
+      <Carousel.Item class="{basis} h-full">
+        <div class="p-2 sm:p-0.5 h-full">
+          <Card.Root class="min-h-[500px]">
+            <Card.Header>
+              <Card.Title>Cursor Tracking</Card.Title>
+            </Card.Header>
+            <Card.Content class="flex flex-col aspect-square border-2 border-bg rounded-lg m-2">
+              <div
+                bind:this={container}
+                class="flex items-center justify-center p-6 relative h-full w-full inset-0"
+              >
+                  <div
+                  class="absolute rounded-full bg-primary w-4 h-4"
+                  style="left: {Math.min(Math.max(cursor.current.x - cursorContainer.x, -16), cursorContainer.width)}px;
+                       top: {Math.min(Math.max(cursor.current.y - cursorContainer.y * 5, 8), cursorContainer.height)}px">
+                  </div>
+                x: {Math.round(cursor.current.x)}px <br>
+                y: {Math.round(cursor.current.y)}px
+              </div>
+            </Card.Content>
+          </Card.Root>
+        </div>
+      </Carousel.Item>
+    {/if}
     <Carousel.Item class={basis}>
       <div class="p-2 sm:p-0.5">
         <Card.Root class="min-h-[500px]">


### PR DESCRIPTION
This PR disables the global flashlight effect and the cursor tracking demo on devices without hover capability (mobile). This addresses performance issues where expensive gradient calculations and tween updates were running on every touch event. 

Key changes:
- Implemented a `canHover` check using `window.matchMedia('(hover: hover)').matches`.
- Guarded `handleMouseMove` and event listener registration in `+layout.svelte`.
- Conditionally rendered the flashlight overlay div.
- Applied similar logic to the playground page to disable its cursor tracking card.
- Fixed a Svelte 5 warning in the playground by making the `container` ref reactive.

---
*PR created automatically by Jules for task [17942694259654363252](https://jules.google.com/task/17942694259654363252) started by @dnnsmnstrr*