### PR TITLE
Disable page scrolling when command palette is active

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -370,7 +370,9 @@
 
 		<main
 			class={cn(
-				`inset-0 h-max max-h-screen w-full flex-grow ${$isCommandActive ? 'overflow-hidden' : 'overflow-y-auto'} ${isFullWidth ? 'p-0' : 'py-4 sm:px-16'} print:max-h-none`,
+				'inset-0 h-max max-h-screen w-full flex-grow print:max-h-none',
+				$isCommandActive ? 'overflow-hidden' : 'overflow-y-auto',
+				isFullWidth ? 'p-0' : 'py-4 sm:px-16',
 				`theme-${$theme}`
 			)}
 			style={bgStyle}


### PR DESCRIPTION
This PR fixes the issue where the background page remained scrollable when the command palette was active. 

Key changes:
- Refactored large `$effect` blocks in `src/routes/+layout.svelte` into smaller, granular effects to improve reactivity and reliability.
- Updated the class application for the `<main>` element to use separate arguments for the `cn` utility, ensuring that `overflow-hidden` correctly overrides `overflow-y-auto` when `$isCommandActive` is true.
- Verified the fix with a new E2E test and manual frontend verification (video and screenshots).

---
*PR created automatically by Jules for task [2236656473115837397](https://jules.google.com/task/2236656473115837397) started by @dnnsmnstrr*