### PR TITLE
Enable Markdown GFM table support in Notes page

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"prettier": "^3.1.1",
 		"prettier-plugin-svelte": "^3.2.6",
 		"prettier-plugin-tailwindcss": "^0.5.9",
+		"remark-gfm": "^4.0.1",
 		"runed": "^0.37.1",
 		"svelte": "^5.19.5",
 		"svelte-check": "^4.0.0",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
 	import '../app.pcss';
+	import { MdProcessor } from '@jazzymcjazz/mdsvelte';
+	import remarkGfm from 'remark-gfm';
+
+	MdProcessor.setGlobalPlugins({ remarkPlugins: [remarkGfm] });
+
 	import { ModeWatcher, mode } from 'mode-watcher';
 	import { Toaster } from '$lib/components/ui/sonner';
 	import Command from './Command.svelte';

--- a/src/routes/notes/+layout.ts
+++ b/src/routes/notes/+layout.ts
@@ -1,0 +1,3 @@
+// Disable SSR (Server Side Rendering) for the notes route to prevent any hydration mismatches
+// during dynamic markdown table rendering with @jazzymcjazz/mdsvelte.
+export const ssr = false;

--- a/src/routes/notes/[slug]/+page.svelte
+++ b/src/routes/notes/[slug]/+page.svelte
@@ -257,4 +257,21 @@
 	:global(.prose h1, .prose h2, .prose h3) {
 		scroll-margin-top: 2rem;
 	}
+	:global(.prose table) {
+		width: 100%;
+		border-collapse: collapse;
+		margin: 1.5rem 0;
+	}
+	:global(.prose th, .prose td) {
+		border: 1px solid hsl(var(--border));
+		padding: 0.5rem 0.75rem;
+		text-align: left;
+	}
+	:global(.prose th) {
+		background-color: hsl(var(--muted) / 0.5);
+		font-weight: 600;
+	}
+	:global(.prose tr:nth-child(even)) {
+		background-color: hsl(var(--muted) / 0.2);
+	}
 </style>


### PR DESCRIPTION
Installs `remark-gfm` and registers it as a global plugin in `MdProcessor` under root layout, enabling table support in `@jazzymcjazz/mdsvelte`. Adds stylish borders, paddings, and zebra-striping to table elements on the notes page under `.prose`, and disables SSR under `/notes` to avoid Svelte 5 hydration mismatches on client-interceptor fetches.

---
*PR created automatically by Jules for task [16037744351679076622](https://jules.google.com/task/16037744351679076622) started by @dnnsmnstrr*