### PR TITLE
Implement GoatCounter tracking for redirects

### DIFF
--- a/src/lib/utils/analytics.test.ts
+++ b/src/lib/utils/analytics.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { trackRedirect } from './analytics';
+
+describe('analytics utilities', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		// Set up clean global state
+		if (typeof window !== 'undefined') {
+			delete (window as any).goatcounter;
+		} else {
+			(global as any).window = {};
+		}
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it('should gracefully handle server-side environments (no window)', () => {
+		const originalWindow = global.window;
+		// Temporarily delete window
+		delete (global as any).window;
+
+		const callback = vi.fn();
+		trackRedirect('github', callback);
+
+		expect(callback).toHaveBeenCalled();
+
+		// Restore original window
+		global.window = originalWindow;
+	});
+
+	it('should track immediately if goatcounter is already loaded', () => {
+		const mockCount = vi.fn();
+		(window as any).goatcounter = { count: mockCount };
+
+		const callback = vi.fn();
+		trackRedirect('github', callback);
+
+		expect(mockCount).toHaveBeenCalledWith({
+			path: 'redirect-github',
+			title: 'Redirect: github',
+			event: true
+		});
+
+		// Check callback is called after 100ms safe delay
+		expect(callback).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(100);
+		expect(callback).toHaveBeenCalled();
+	});
+
+	it('should track after polling if goatcounter loads with a delay', () => {
+		const mockCount = vi.fn();
+		const callback = vi.fn();
+
+		trackRedirect('instagram', callback);
+
+		// Not loaded initially
+		expect(mockCount).not.toHaveBeenCalled();
+
+		// Advance timer to first interval (100ms)
+		vi.advanceTimersByTime(100);
+		expect(mockCount).not.toHaveBeenCalled();
+
+		// Simulate GoatCounter loading
+		(window as any).goatcounter = { count: mockCount };
+
+		// Advance to next interval (200ms)
+		vi.advanceTimersByTime(100);
+		expect(mockCount).toHaveBeenCalledWith({
+			path: 'redirect-instagram',
+			title: 'Redirect: instagram',
+			event: true
+		});
+
+		// Check callback is called after safety delay
+		expect(callback).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(100);
+		expect(callback).toHaveBeenCalled();
+	});
+
+	it('should timeout and call callback anyway if goatcounter fails to load within 500ms', () => {
+		const callback = vi.fn();
+
+		trackRedirect('twitter', callback);
+
+		// Advance time 500ms (5 attempts)
+		vi.advanceTimersByTime(500);
+
+		// Callback should have been called despite missing GoatCounter
+		expect(callback).toHaveBeenCalled();
+	});
+});

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -1,0 +1,51 @@
+/**
+ * Tracks a redirect event using GoatCounter's JavaScript API.
+ * Since count.js is loaded asynchronously, this function attempts to wait
+ * for the API to load before sending the event. It uses a timeout to prevent
+ * hanging if GoatCounter is blocked by an ad-blocker.
+ *
+ * @param name The name of the redirect (e.g., 'github')
+ * @param callback Optional callback to execute after the event has been tracked or skipped
+ */
+export function trackRedirect(name: string, callback?: () => void) {
+	if (typeof window === 'undefined') {
+		if (callback) callback();
+		return;
+	}
+
+	const track = () => {
+		const goatcounter = (window as any).goatcounter;
+		if (goatcounter && typeof goatcounter.count === 'function') {
+			goatcounter.count({
+				path: 'redirect-' + name.toLowerCase(),
+				title: 'Redirect: ' + name,
+				event: true
+			});
+		}
+	};
+
+	// If goatcounter is already loaded, track and execute callback with a safe delay
+	if ((window as any).goatcounter && typeof (window as any).goatcounter.count === 'function') {
+		track();
+		if (callback) {
+			setTimeout(callback, 100);
+		}
+		return;
+	}
+
+	// If goatcounter is not yet loaded, wait up to 500ms
+	let attempts = 0;
+	const interval = setInterval(() => {
+		attempts++;
+		if ((window as any).goatcounter && typeof (window as any).goatcounter.count === 'function') {
+			clearInterval(interval);
+			track();
+			if (callback) {
+				setTimeout(callback, 100);
+			}
+		} else if (attempts >= 5) { // 500ms timeout
+			clearInterval(interval);
+			if (callback) callback();
+		}
+	}, 100);
+}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -6,6 +6,7 @@
 	import { browser } from '$app/environment';
 	import { onMount } from 'svelte';
 	import { i18n } from '$lib/i18n/i18n.svelte';
+	import { trackRedirect } from '$lib/utils/analytics';
 
 	// During SSR there is no window, so show the error content immediately.
 	// On the client, onMount will attempt a redirect lookup first.
@@ -17,7 +18,12 @@
 		const hasLoopedBack = window.location.search.includes('noRedirect');
 		if (foundRedirect && !foundRedirect.toString().includes('404') && !hasLoopedBack) {
 			const isExternal = typeof foundRedirect === 'string' && foundRedirect.startsWith('http');
-			window.location.replace(foundRedirect + (!isExternal ? '?noRedirect=true' : ''));
+			const redirectObj = getRedirect(query, redirects, { returnObject: true });
+			const name = (typeof redirectObj === 'object' && redirectObj?.name) ? redirectObj.name : query;
+
+			trackRedirect(name, () => {
+				window.location.replace(foundRedirect + (!isExternal ? '?noRedirect=true' : ''));
+			});
 		} else {
 			loading = false;
 		}

--- a/src/routes/api/redirect/[query]/+server.ts
+++ b/src/routes/api/redirect/[query]/+server.ts
@@ -1,8 +1,40 @@
 import { redirect } from '@sveltejs/kit';
 import { redirects } from '$lib/redirects';
 import { getRedirect } from '$lib/utils/redirect';
+import { GOATCOUNTER_API_KEY } from '$env/static/private';
 
-export async function GET({ params }) {
+export async function GET({ params, request }) {
+	const redirectObj = getRedirect(params.query, redirects, { returnObject: true });
 	const foundRedirect = getRedirect(params.query, redirects);
+
+	if (foundRedirect && !foundRedirect.toString().includes('404')) {
+		const name = (typeof redirectObj === 'object' && redirectObj?.name) ? redirectObj.name : params.query;
+		if (GOATCOUNTER_API_KEY) {
+			try {
+				await fetch('https://dnnsmnstrr.goatcounter.com/api/v0/count', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						Authorization: `Bearer ${GOATCOUNTER_API_KEY}`
+					},
+					body: JSON.stringify({
+						no_sessions: true,
+						hits: [
+							{
+								path: `redirect-${name.toLowerCase()}`,
+								title: `Redirect: ${name}`,
+								event: true,
+								user_agent: request.headers.get('user-agent') || undefined,
+								ref: request.headers.get('referer') || undefined
+							}
+						]
+					})
+				});
+			} catch (e) {
+				console.error('Failed to track backend redirect to GoatCounter:', e);
+			}
+		}
+	}
+
 	throw redirect(302, String(foundRedirect));
 }

--- a/src/routes/redirects/+page.svelte
+++ b/src/routes/redirects/+page.svelte
@@ -6,6 +6,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import { getRedirectURL, type Redirect } from '$lib/utils/redirect';
 	import Button from '$lib/components/ui/button/button.svelte';
+	import { trackRedirect } from '$lib/utils/analytics';
 	import {
 		DropdownMenu,
 		DropdownMenuContent,
@@ -20,6 +21,7 @@
 	let { data } = $props();
 	function handleRedirect(redirect: Redirect) {
 		const redirectUrl = getRedirectURL(redirect);
+		trackRedirect(redirect.name);
 		window.open(redirectUrl, '_blank');
 	}
 	let filterQuery = $state('');
@@ -92,8 +94,11 @@
 					if (redirect) {
 						const url = getRedirectURL(redirect);
 						if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
-							window.open(url, '_self');
+							trackRedirect(redirect.name, () => {
+								window.open(url, '_self');
+							});
 						} else {
+							trackRedirect(redirect.name);
 							window.open(url, '_blank', 'noopener,noreferrer');
 						}
 					}


### PR DESCRIPTION
This PR implements GoatCounter tracking for muenstererOS redirects. Client-side, it uses GoatCounter's JS API to track custom events ('redirect-[name]') when shortcuts are used or redirects are clicked. Server-side, it uses the POST `/api/v0/count` endpoint to track API redirects when the GOATCOUNTER_API_KEY is available. Full unit tests have been written and validated.

---
*PR created automatically by Jules for task [3796119848435055900](https://jules.google.com/task/3796119848435055900) started by @dnnsmnstrr*