### PR TITLE
Maximize notes view and add collapsible sidebar

### DIFF
--- a/src/data/note-recommendations.ts
+++ b/src/data/note-recommendations.ts
@@ -1,0 +1,12 @@
+export type NoteRecommendation = {
+	slug: string;
+	reason?: string;
+};
+
+export const noteRecommendations = [
+	// Add recommended notes here, for example:
+	// { slug: 'building-muensterer-os', reason: 'A tour of how this website works.' }
+	{ slug: 'ideas', reason: 'Some of my ideas.' },
+	{ slug: 'kickstarter', reason: 'My Kickstarter experience.' },
+	{ slug: 'defaults', reason: 'The default apps I use.' }
+] satisfies NoteRecommendation[];

--- a/src/lib/components/typography/Blockquote.svelte
+++ b/src/lib/components/typography/Blockquote.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let { children }: { node: import('mdast').Blockquote; children?: Snippet } = $props();
+</script>
+
+<blockquote
+	class="my-6 border-l-2 border-primary pl-4 italic text-muted-foreground [&>p]:my-2 [&>p:first-child]:mt-0 [&>p:last-child]:mb-0"
+>
+	{@render children?.()}
+</blockquote>

--- a/src/lib/components/typography/Code.svelte
+++ b/src/lib/components/typography/Code.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { Check, Copy } from 'lucide-svelte';
+	import { onDestroy } from 'svelte';
+
+	let { node }: { node: import('mdast').Code } = $props();
+	let copied = $state(false);
+	let resetTimer: ReturnType<typeof setTimeout> | undefined;
+
+	async function copyCode() {
+		try {
+			await navigator.clipboard.writeText(node.value);
+			copied = true;
+			clearTimeout(resetTimer);
+			resetTimer = setTimeout(() => (copied = false), 2000);
+		} catch (error) {
+			console.error('Failed to copy code:', error);
+		}
+	}
+
+	onDestroy(() => clearTimeout(resetTimer));
+</script>
+
+<div class="group relative my-6">
+	<div class="absolute inset-x-2 top-2 flex h-7 items-center justify-between pl-2">
+		<span
+			class="select-none text-xs uppercase tracking-wide text-muted-foreground"
+		>
+			{node.lang || 'code'}
+		</span>
+		<Button
+			variant="ghost"
+			size="icon"
+			class="size-7"
+			onclick={copyCode}
+			title={copied ? 'Copied' : 'Copy code'}
+			aria-label={copied ? 'Code copied' : 'Copy code'}
+		>
+			{#if copied}<Check class="size-4" />{:else}<Copy class="size-4" />{/if}
+		</Button>
+	</div>
+	<pre
+		class="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 pt-12 text-sm leading-relaxed text-foreground"
+	><code class={node.lang ? `language-${node.lang}` : undefined}>{node.value}</code></pre>
+</div>

--- a/src/lib/components/typography/index.ts
+++ b/src/lib/components/typography/index.ts
@@ -1,3 +1,4 @@
+import Blockquote from './Blockquote.svelte';
 import Heading from './Heading.svelte';
 import Kbd from './Kbd.svelte';
 import Link from './Link.svelte';
@@ -9,9 +10,10 @@ export type TypographyContext = {
 };
 
 const renderers = {
+	blockquote: Blockquote,
 	heading: Heading,
 	link: Link,
 	list: List
 };
 
-export { renderers, Heading, Kbd, Link, List };
+export { renderers, Blockquote, Heading, Kbd, Link, List };

--- a/src/lib/components/typography/index.ts
+++ b/src/lib/components/typography/index.ts
@@ -1,4 +1,5 @@
 import Blockquote from './Blockquote.svelte';
+import Code from './Code.svelte';
 import Heading from './Heading.svelte';
 import Kbd from './Kbd.svelte';
 import Link from './Link.svelte';
@@ -11,9 +12,10 @@ export type TypographyContext = {
 
 const renderers = {
 	blockquote: Blockquote,
+	code: Code,
 	heading: Heading,
 	link: Link,
 	list: List
 };
 
-export { renderers, Blockquote, Heading, Kbd, Link, List };
+export { renderers, Blockquote, Code, Heading, Kbd, Link, List };

--- a/src/lib/stores/notes.ts
+++ b/src/lib/stores/notes.ts
@@ -1,0 +1,5 @@
+import { writable } from 'svelte/store';
+
+// Keep the notes page maximization and sidebar collapse state synced across page navigations.
+export const isNotesMaximized = writable(false);
+export const isNotesSidebarCollapsed = writable(false);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -56,7 +56,8 @@
 		AtSign,
 		Ship,
 		Trophy,
-		Cog
+		Cog,
+		FileText
 	} from 'lucide-svelte';
 	import type { BookmarkItem } from './Menu.svelte';
 	import { PAGE_TITLE_SUFFIX } from '$lib/config';
@@ -259,6 +260,7 @@
 
 	const bookmarksRaw: BookmarkItem[] = [
 		{ name: 'Now', href: '/now', icon: CalendarClock },
+		{ name: 'Notes', href: '/notes', icon: FileText },
 		{ name: 'Uses', href: '/uses', icon: TabletSmartphone },
 		{ name: 'Projects', href: '/projects', icon: LayoutGrid },
 		{ name: 'Playlists', href: '/playlists', icon: ListMusic },

--- a/src/routes/api/notes/recommendations/+server.ts
+++ b/src/routes/api/notes/recommendations/+server.ts
@@ -1,0 +1,6 @@
+import { noteRecommendations } from '../../../../data/note-recommendations';
+import { json } from '@sveltejs/kit';
+
+export function GET() {
+	return json(noteRecommendations);
+}

--- a/src/routes/notes/+page.svelte
+++ b/src/routes/notes/+page.svelte
@@ -47,8 +47,8 @@
 </svelte:head>
 
 {#if isMaximized}
-	<!-- Maximized layout for notes overview -->
-	<div class="fixed inset-x-0 bottom-0 top-[5.5rem] z-40 flex flex-col bg-background p-0 sm:px-16 pb-4">
+	<!-- Maximized layout for notes overview (full width) -->
+	<div class="fixed inset-x-0 bottom-0 top-[5.5rem] z-40 flex flex-col bg-background p-0 pb-4">
 		<!-- Toolbar for Maximized Mode -->
 		<div class="flex items-center justify-between border-b border-border bg-background px-4 py-2 sm:px-8 shrink-0">
 			<span class="text-sm font-semibold tracking-tight text-muted-foreground">

--- a/src/routes/notes/+page.svelte
+++ b/src/routes/notes/+page.svelte
@@ -1,32 +1,23 @@
 <script lang="ts">
-	import Window from '$lib/components/ui/window/window.svelte';
+	import NotesLayout from './NotesLayout.svelte';
 	import { Heading } from '$lib/components/typography';
-	import { i18n } from '$lib/i18n/i18n.svelte';
-	import { onMount } from 'svelte';
-	import { FileText, Search, Minimize2 } from 'lucide-svelte';
 	import { PAGE_TITLE_SUFFIX } from '$lib/config';
-	import { isNotesMaximized } from '$lib/stores/notes';
-	import { Button } from '$lib/components/ui/button';
+	import { i18n } from '$lib/i18n/i18n.svelte';
+	import { ArrowRight, FileText } from 'lucide-svelte';
+	import { onMount } from 'svelte';
 
-	let notes = $state<any[]>([]);
+	let notes = $state<{ name: string }[]>([]);
+	let recommendations = $state<{ slug: string; reason?: string }[]>([]);
 	let loading = $state(true);
 	let searchQuery = $state('');
-
-	let isMaximized = $state(false);
-
-	isNotesMaximized.subscribe((val) => {
-		isMaximized = val;
-	});
-
-	function toggleMaximize(val: boolean) {
-		isNotesMaximized.set(val);
-	}
 
 	onMount(async () => {
 		try {
 			const response = await fetch('/api/notes');
-			if (response.ok) {
-				notes = await response.json();
+			if (response.ok) notes = await response.json();
+			const recResponse = await fetch('/api/notes/recommendations');
+			if (recResponse.ok) {
+				recommendations = await recResponse.json();
 			}
 		} catch (error) {
 			console.error('Failed to fetch notes:', error);
@@ -34,152 +25,49 @@
 			loading = false;
 		}
 	});
-
-	const filteredNotes = $derived(
-		notes.filter((note) =>
-			note.name.toLowerCase().includes(searchQuery.toLowerCase())
-		)
-	);
 </script>
 
 <svelte:head>
 	<title>{i18n.t('notes.title')}{PAGE_TITLE_SUFFIX}</title>
 </svelte:head>
 
-{#if isMaximized}
-	<!-- Maximized layout for notes overview (full width) -->
-	<div class="fixed inset-x-0 bottom-0 top-[5.5rem] z-40 flex flex-col bg-background p-0 pb-4">
-		<!-- Toolbar for Maximized Mode -->
-		<div class="flex items-center justify-between border-b border-border bg-background px-4 py-2 sm:px-8 shrink-0">
-			<span class="text-sm font-semibold tracking-tight text-muted-foreground">
-				{i18n.t('notes.title') || 'Notes'}
-			</span>
-			<div class="flex items-center gap-2">
-				<!-- Restore Button -->
-				<Button
-					variant="ghost"
-					size="icon"
-					onclick={() => toggleMaximize(false)}
-					title={i18n.t('window.restore') || 'Restore Window'}
-					class="size-8"
-				>
-					<Minimize2 class="size-5" />
-				</Button>
-			</div>
-		</div>
+<NotesLayout
+	{notes}
+	{loading}
+	bind:searchQuery
+	title={i18n.t('notes.title') || 'Notes'}
+>
+	<div class="hidden h-full flex-grow flex-col overflow-y-auto bg-background p-8 md:flex">
+		<div class="mx-auto w-full max-w-3xl">
+			<Heading class="mb-8">{i18n.t('notes.title') || 'Notes'}</Heading>
+			<p class="mb-10 text-muted-foreground">
+				{i18n.t('notes.welcome') || 'Select a note from the sidebar to start reading.'}
+			</p>
 
-		<!-- Inner maximized container -->
-		<div class="flex flex-grow min-h-0 overflow-hidden divide-x divide-border">
-			<!-- Sidebar -->
-			<div class="w-full md:w-64 flex flex-col bg-muted/30 h-full overflow-hidden shrink-0">
-				<div class="p-4 border-b border-border shrink-0">
-					<div class="relative">
-						<Search class="absolute left-2 top-2.5 size-4 text-muted-foreground" />
-						<input
-							type="text"
-							placeholder={i18n.t('notes.search_placeholder') || 'Search notes...'}
-							bind:value={searchQuery}
-							class="w-full pl-8 pr-4 py-2 bg-background border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary"
-						/>
-					</div>
-				</div>
-				<div class="flex-grow overflow-y-auto">
-					{#if loading}
-						<div class="p-4 text-center text-muted-foreground">
-							{i18n.t('common.loading') || 'Loading...'}
-						</div>
-					{:else if filteredNotes.length === 0}
-						<div class="p-4 text-center text-muted-foreground">
-							{i18n.t('notes.no_notes') || 'No notes found'}
-						</div>
-					{:else}
-						<ul class="divide-y divide-border/50">
-							{#each filteredNotes as note}
-								<li>
-									<a
-										href="/notes/{note.name}"
-										class="flex items-center gap-3 p-4 hover:bg-muted transition-colors"
-									>
-										<FileText class="size-4 text-muted-foreground" />
-										<span class="text-sm font-medium truncate">{note.name}</span>
-									</a>
-								</li>
-							{/each}
-						</ul>
-					{/if}
-				</div>
-			</div>
-
-			<!-- Main Panel -->
-			<div class="hidden md:flex flex-grow flex-col overflow-y-auto p-8 h-full bg-background">
-				<div class="max-w-3xl mx-auto w-full">
-					<Heading class="mb-8">{i18n.t('notes.title') || 'Notes'}</Heading>
-					<div class="prose dark:prose-invert">
-						<p class="text-muted-foreground">
-							{i18n.t('notes.welcome') || 'Select a note from the sidebar to start reading.'}
-						</p>
-					</div>
-				</div>
-			</div>
+			{#if recommendations.length > 0}
+				<section aria-labelledby="recommendations-heading">
+					<Heading id="recommendations-heading" depth={2} class="mb-4">Recommendations</Heading>
+					<ul class="grid gap-3">
+						{#each recommendations as recommendation}
+							<li>
+								<a
+									href="/notes/{recommendation.slug}"
+									class="group flex items-center gap-4 rounded-lg border border-border p-4 transition-colors hover:bg-muted/50"
+								>
+									<FileText class="size-5 shrink-0 text-muted-foreground group-hover:text-primary" />
+									<div class="min-w-0 flex-grow">
+										<p class="truncate font-medium">{recommendation.slug}</p>
+										{#if recommendation.reason}
+											<p class="mt-1 text-sm text-muted-foreground">{recommendation.reason}</p>
+										{/if}
+									</div>
+									<ArrowRight class="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-1 group-hover:text-primary" />
+								</a>
+							</li>
+						{/each}
+					</ul>
+				</section>
+			{/if}
 		</div>
 	</div>
-{:else}
-	<!-- Standard Window layout -->
-	<div class="container mx-auto p-4 h-[calc(100vh-8rem)] flex flex-col">
-		<Window class="flex-grow flex flex-col min-h-0 overflow-hidden" onMaximize={() => toggleMaximize(true)} {isMaximized}>
-			<div class="flex flex-col md:flex-row h-full md:divide-x divide-border">
-				<!-- Sidebar -->
-				<div class="w-full md:w-64 flex flex-col bg-muted/30 h-full overflow-hidden">
-					<div class="p-4 border-b border-border shrink-0">
-						<div class="relative">
-							<Search class="absolute left-2 top-2.5 size-4 text-muted-foreground" />
-							<input
-								type="text"
-								placeholder={i18n.t('notes.search_placeholder') || 'Search notes...'}
-								bind:value={searchQuery}
-								class="w-full pl-8 pr-4 py-2 bg-background border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary"
-							/>
-						</div>
-					</div>
-					<div class="flex-grow overflow-y-auto">
-						{#if loading}
-							<div class="p-4 text-center text-muted-foreground">
-								{i18n.t('common.loading') || 'Loading...'}
-							</div>
-						{:else if filteredNotes.length === 0}
-							<div class="p-4 text-center text-muted-foreground">
-								{i18n.t('notes.no_notes') || 'No notes found'}
-							</div>
-						{:else}
-							<ul class="divide-y divide-border/50">
-								{#each filteredNotes as note}
-									<li>
-										<a
-											href="/notes/{note.name}"
-											class="flex items-center gap-3 p-4 hover:bg-muted transition-colors"
-										>
-											<FileText class="size-4 text-muted-foreground" />
-											<span class="text-sm font-medium truncate">{note.name}</span>
-										</a>
-									</li>
-								{/each}
-							</ul>
-						{/if}
-					</div>
-				</div>
-
-				<!-- Main Panel - Hidden on mobile -->
-				<div class="hidden md:flex flex-grow flex-col overflow-y-auto p-8 h-full">
-					<div class="max-w-3xl mx-auto w-full">
-						<Heading class="mb-8">{i18n.t('notes.title') || 'Notes'}</Heading>
-						<div class="prose dark:prose-invert">
-							<p class="text-muted-foreground">
-								{i18n.t('notes.welcome') || 'Select a note from the sidebar to start reading.'}
-							</p>
-						</div>
-					</div>
-				</div>
-			</div>
-		</Window>
-	</div>
-{/if}
+</NotesLayout>

--- a/src/routes/notes/+page.svelte
+++ b/src/routes/notes/+page.svelte
@@ -3,12 +3,24 @@
 	import { Heading } from '$lib/components/typography';
 	import { i18n } from '$lib/i18n/i18n.svelte';
 	import { onMount } from 'svelte';
-	import { FileText, Search } from 'lucide-svelte';
+	import { FileText, Search, Minimize2 } from 'lucide-svelte';
 	import { PAGE_TITLE_SUFFIX } from '$lib/config';
+	import { isNotesMaximized } from '$lib/stores/notes';
+	import { Button } from '$lib/components/ui/button';
 
 	let notes = $state<any[]>([]);
 	let loading = $state(true);
 	let searchQuery = $state('');
+
+	let isMaximized = $state(false);
+
+	isNotesMaximized.subscribe((val) => {
+		isMaximized = val;
+	});
+
+	function toggleMaximize(val: boolean) {
+		isNotesMaximized.set(val);
+	}
 
 	onMount(async () => {
 		try {
@@ -34,11 +46,32 @@
 	<title>{i18n.t('notes.title')}{PAGE_TITLE_SUFFIX}</title>
 </svelte:head>
 
-<div class="container mx-auto p-4 h-[calc(100vh-8rem)] flex flex-col">
-	<Window class="flex-grow flex flex-col min-h-0 overflow-hidden">
-		<div class="flex flex-col md:flex-row h-full md:divide-x divide-border">
+{#if isMaximized}
+	<!-- Maximized layout for notes overview -->
+	<div class="fixed inset-x-0 bottom-0 top-[5.5rem] z-40 flex flex-col bg-background p-0 sm:px-16 pb-4">
+		<!-- Toolbar for Maximized Mode -->
+		<div class="flex items-center justify-between border-b border-border bg-background px-4 py-2 sm:px-8 shrink-0">
+			<span class="text-sm font-semibold tracking-tight text-muted-foreground">
+				{i18n.t('notes.title') || 'Notes'}
+			</span>
+			<div class="flex items-center gap-2">
+				<!-- Restore Button -->
+				<Button
+					variant="ghost"
+					size="icon"
+					onclick={() => toggleMaximize(false)}
+					title={i18n.t('window.restore') || 'Restore Window'}
+					class="size-8"
+				>
+					<Minimize2 class="size-5" />
+				</Button>
+			</div>
+		</div>
+
+		<!-- Inner maximized container -->
+		<div class="flex flex-grow min-h-0 overflow-hidden divide-x divide-border">
 			<!-- Sidebar -->
-			<div class="w-full md:w-64 flex flex-col bg-muted/30 h-full overflow-hidden">
+			<div class="w-full md:w-64 flex flex-col bg-muted/30 h-full overflow-hidden shrink-0">
 				<div class="p-4 border-b border-border shrink-0">
 					<div class="relative">
 						<Search class="absolute left-2 top-2.5 size-4 text-muted-foreground" />
@@ -77,8 +110,8 @@
 				</div>
 			</div>
 
-			<!-- Main Panel - Hidden on mobile -->
-			<div class="hidden md:flex flex-grow flex-col overflow-y-auto p-8 h-full">
+			<!-- Main Panel -->
+			<div class="hidden md:flex flex-grow flex-col overflow-y-auto p-8 h-full bg-background">
 				<div class="max-w-3xl mx-auto w-full">
 					<Heading class="mb-8">{i18n.t('notes.title') || 'Notes'}</Heading>
 					<div class="prose dark:prose-invert">
@@ -89,5 +122,64 @@
 				</div>
 			</div>
 		</div>
-	</Window>
-</div>
+	</div>
+{:else}
+	<!-- Standard Window layout -->
+	<div class="container mx-auto p-4 h-[calc(100vh-8rem)] flex flex-col">
+		<Window class="flex-grow flex flex-col min-h-0 overflow-hidden" onMaximize={() => toggleMaximize(true)} {isMaximized}>
+			<div class="flex flex-col md:flex-row h-full md:divide-x divide-border">
+				<!-- Sidebar -->
+				<div class="w-full md:w-64 flex flex-col bg-muted/30 h-full overflow-hidden">
+					<div class="p-4 border-b border-border shrink-0">
+						<div class="relative">
+							<Search class="absolute left-2 top-2.5 size-4 text-muted-foreground" />
+							<input
+								type="text"
+								placeholder={i18n.t('notes.search_placeholder') || 'Search notes...'}
+								bind:value={searchQuery}
+								class="w-full pl-8 pr-4 py-2 bg-background border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+							/>
+						</div>
+					</div>
+					<div class="flex-grow overflow-y-auto">
+						{#if loading}
+							<div class="p-4 text-center text-muted-foreground">
+								{i18n.t('common.loading') || 'Loading...'}
+							</div>
+						{:else if filteredNotes.length === 0}
+							<div class="p-4 text-center text-muted-foreground">
+								{i18n.t('notes.no_notes') || 'No notes found'}
+							</div>
+						{:else}
+							<ul class="divide-y divide-border/50">
+								{#each filteredNotes as note}
+									<li>
+										<a
+											href="/notes/{note.name}"
+											class="flex items-center gap-3 p-4 hover:bg-muted transition-colors"
+										>
+											<FileText class="size-4 text-muted-foreground" />
+											<span class="text-sm font-medium truncate">{note.name}</span>
+										</a>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+					</div>
+				</div>
+
+				<!-- Main Panel - Hidden on mobile -->
+				<div class="hidden md:flex flex-grow flex-col overflow-y-auto p-8 h-full">
+					<div class="max-w-3xl mx-auto w-full">
+						<Heading class="mb-8">{i18n.t('notes.title') || 'Notes'}</Heading>
+						<div class="prose dark:prose-invert">
+							<p class="text-muted-foreground">
+								{i18n.t('notes.welcome') || 'Select a note from the sidebar to start reading.'}
+							</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</Window>
+	</div>
+{/if}

--- a/src/routes/notes/+page.svelte
+++ b/src/routes/notes/+page.svelte
@@ -1,15 +1,24 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import NotesLayout from './NotesLayout.svelte';
 	import { Heading } from '$lib/components/typography';
+	import { Button } from '$lib/components/ui/button';
 	import { PAGE_TITLE_SUFFIX } from '$lib/config';
 	import { i18n } from '$lib/i18n/i18n.svelte';
-	import { ArrowRight, FileText } from 'lucide-svelte';
+	import { ArrowRight, FileText, Shuffle } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 
 	let notes = $state<{ name: string }[]>([]);
 	let recommendations = $state<{ slug: string; reason?: string }[]>([]);
 	let loading = $state(true);
 	let searchQuery = $state('');
+
+	function openRandomNote() {
+		if (notes.length === 0) return;
+
+		const randomNote = notes[Math.floor(Math.random() * notes.length)];
+		goto(`/notes/${encodeURIComponent(randomNote.name)}`);
+	}
 
 	onMount(async () => {
 		try {
@@ -31,11 +40,26 @@
 	<title>{i18n.t('notes.title')}{PAGE_TITLE_SUFFIX}</title>
 </svelte:head>
 
+{#snippet shuffleButton()}
+	<Button
+		variant="ghost"
+		size="icon"
+		onclick={openRandomNote}
+		disabled={loading || notes.length === 0}
+		title="Open a random note"
+		aria-label="Open a random note"
+	>
+		<Shuffle class="size-4" />
+	</Button>
+{/snippet}
+
 <NotesLayout
 	{notes}
 	{loading}
 	bind:searchQuery
 	title={i18n.t('notes.title') || 'Notes'}
+	titlebarRight={shuffleButton}
+	toolbarActions={shuffleButton}
 >
 	<div class="hidden h-full flex-grow flex-col overflow-y-auto bg-background p-8 md:flex">
 		<div class="mx-auto w-full max-w-3xl">
@@ -46,7 +70,7 @@
 
 			{#if recommendations.length > 0}
 				<section aria-labelledby="recommendations-heading">
-					<Heading id="recommendations-heading" depth={2} class="mb-4">Recommendations</Heading>
+					<Heading depth={3} class="mb-4">Recommendations</Heading>
 					<ul class="grid gap-3">
 						{#each recommendations as recommendation}
 							<li>

--- a/src/routes/notes/NotesLayout.svelte
+++ b/src/routes/notes/NotesLayout.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+	import Window from '$lib/components/ui/window/window.svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { i18n } from '$lib/i18n/i18n.svelte';
+	import { isNotesMaximized, isNotesSidebarCollapsed } from '$lib/stores/notes';
+	import { FileText, Minimize2, PanelLeftClose, PanelLeftOpen, Search } from 'lucide-svelte';
+	import { onDestroy, type Snippet } from 'svelte';
+
+	interface NoteListItem {
+		name: string;
+	}
+
+	let {
+		notes,
+		loading,
+		activeSlug,
+		title,
+		searchQuery = $bindable(''),
+		collapsibleSidebar = false,
+		titlebarRight,
+		toolbarActions,
+		children
+	}: {
+		notes: NoteListItem[];
+		loading: boolean;
+		activeSlug?: string;
+		title: string;
+		searchQuery?: string;
+		collapsibleSidebar?: boolean;
+		titlebarRight?: Snippet;
+		toolbarActions?: Snippet;
+		children: Snippet;
+	} = $props();
+
+	let isMaximized = $state(false);
+	let isSidebarCollapsed = $state(false);
+
+	const unsubscribeMaximized = isNotesMaximized.subscribe((value) => (isMaximized = value));
+	const unsubscribeSidebar = isNotesSidebarCollapsed.subscribe(
+		(value) => (isSidebarCollapsed = value)
+	);
+
+	onDestroy(() => {
+		unsubscribeMaximized();
+		unsubscribeSidebar();
+	});
+
+	const filteredNotes = $derived(
+		notes.filter((note) => note.name.toLowerCase().includes(searchQuery.toLowerCase()))
+	);
+
+	function toggleMaximize(value: boolean) {
+		isNotesMaximized.set(value);
+	}
+
+	function toggleSidebar(value: boolean) {
+		isNotesSidebarCollapsed.set(value);
+	}
+</script>
+
+{#snippet sidebar()}
+	<div class="flex h-full w-full shrink-0 flex-col overflow-hidden bg-muted/30 md:w-64 md:min-w-64">
+		<div class="shrink-0 border-b border-border p-4">
+			<div class="relative">
+				<Search class="absolute left-2 top-2.5 size-4 text-muted-foreground" />
+				<input
+					type="search"
+					placeholder={i18n.t('notes.search_placeholder') || 'Search notes...'}
+					bind:value={searchQuery}
+					class="w-full rounded-md border border-border bg-background py-2 pl-8 pr-4 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+				/>
+			</div>
+		</div>
+		<div class="flex-grow overflow-y-auto">
+			{#if loading}
+				<div class="p-4 text-center text-muted-foreground">
+					{i18n.t('common.loading') || 'Loading...'}
+				</div>
+			{:else if filteredNotes.length === 0}
+				<div class="p-4 text-center text-muted-foreground">
+					{i18n.t('notes.no_notes') || 'No notes found'}
+				</div>
+			{:else}
+				<ul class="divide-y divide-border/50">
+					{#each filteredNotes as note}
+						<li>
+							<a
+								href="/notes/{note.name}"
+								class="flex items-center gap-3 p-4 transition-colors hover:bg-muted {note.name === activeSlug ? 'border-r-2 border-primary bg-muted' : ''}"
+							>
+								<FileText class="size-4 {note.name === activeSlug ? 'text-primary' : 'text-muted-foreground'}" />
+								<span class="truncate text-sm font-medium {note.name === activeSlug ? 'text-primary' : ''}">{note.name}</span>
+							</a>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	</div>
+{/snippet}
+
+{#snippet body(maximized: boolean)}
+	<div class="flex h-full min-h-0 flex-grow overflow-hidden divide-x divide-border">
+		{#if !collapsibleSidebar || !maximized || !isSidebarCollapsed}
+			<div class={activeSlug ? 'hidden md:flex' : 'flex'}>
+				{@render sidebar()}
+			</div>
+		{/if}
+		{@render children()}
+	</div>
+{/snippet}
+
+{#if isMaximized}
+	<div class="fixed inset-x-0 bottom-0 top-[5.5rem] z-40 flex flex-col bg-background pb-4">
+		<div class="flex shrink-0 items-center justify-between border-b border-border bg-background px-4 py-2 sm:px-8">
+			<div class="flex min-w-0 items-center gap-2">
+				{#if collapsibleSidebar}
+					<Button
+						variant="ghost"
+						size="icon"
+						onclick={() => toggleSidebar(!isSidebarCollapsed)}
+						title={isSidebarCollapsed ? i18n.t('notes.expand_sidebar') || 'Expand Sidebar' : i18n.t('notes.collapse_sidebar') || 'Collapse Sidebar'}
+						class="hidden size-8 md:inline-flex"
+					>
+						{#if isSidebarCollapsed}<PanelLeftOpen class="size-5" />{:else}<PanelLeftClose class="size-5" />{/if}
+					</Button>
+				{/if}
+				<span class="truncate text-sm font-semibold tracking-tight text-muted-foreground">{title}</span>
+			</div>
+			<div class="flex items-center gap-2">
+				{@render toolbarActions?.()}
+				{#if toolbarActions}<div class="mx-1 h-4 w-px bg-border"></div>{/if}
+				<Button variant="ghost" size="icon" onclick={() => toggleMaximize(false)} title={i18n.t('window.restore') || 'Restore Window'} class="size-8">
+					<Minimize2 class="size-5" />
+				</Button>
+			</div>
+		</div>
+		{@render body(true)}
+	</div>
+{:else}
+	<div class="container mx-auto flex h-[calc(100vh-8rem)] flex-col p-4">
+		<Window class="flex min-h-0 flex-grow flex-col overflow-hidden" childClassName="p-0" onMaximize={() => toggleMaximize(true)} {isMaximized} {titlebarRight}>
+			{@render body(false)}
+		</Window>
+	</div>
+{/if}

--- a/src/routes/notes/NotesLayout.svelte
+++ b/src/routes/notes/NotesLayout.svelte
@@ -5,6 +5,7 @@
 	import { isNotesMaximized, isNotesSidebarCollapsed } from '$lib/stores/notes';
 	import { FileText, Minimize2, PanelLeftClose, PanelLeftOpen, Search } from 'lucide-svelte';
 	import { onDestroy, type Snippet } from 'svelte';
+	import { goto } from '$app/navigation';
 
 	interface NoteListItem {
 		name: string;
@@ -139,7 +140,13 @@
 	</div>
 {:else}
 	<div class="container mx-auto flex h-[calc(100vh-8rem)] flex-col p-4">
-		<Window class="flex min-h-0 flex-grow flex-col overflow-hidden" childClassName="p-0" onMaximize={() => toggleMaximize(true)} {isMaximized} {titlebarRight}>
+		<Window 
+			class="flex min-h-0 flex-grow flex-col overflow-hidden" 
+			childClassName="p-0" 
+			onClose={() => goto('/notes')}
+			onMaximize={() => toggleMaximize(true)} 
+			{isMaximized} {titlebarRight}
+		>
 			{@render body(false)}
 		</Window>
 	</div>

--- a/src/routes/notes/[slug]/+page.svelte
+++ b/src/routes/notes/[slug]/+page.svelte
@@ -12,6 +12,7 @@
 	import { Toc } from '$lib/components/ui/toc';
 	import * as Popover from '$lib/components/ui/popover';
 	import { Button } from '$lib/components/ui/button';
+	import { isNotesMaximized, isNotesSidebarCollapsed } from '$lib/stores/notes';
 
 	let notes = $state<any[]>([]);
 	let note = $state<any>(null);
@@ -19,9 +20,25 @@
 	let loadingNote = $state(true);
 	let searchQuery = $state('');
 
-	// State for maximized view and collapsible sidebar
+	// Sync local component state with the shared notes store
 	let isMaximized = $state(false);
 	let isLeftSidebarCollapsed = $state(false);
+
+	isNotesMaximized.subscribe((val) => {
+		isMaximized = val;
+	});
+
+	isNotesSidebarCollapsed.subscribe((val) => {
+		isLeftSidebarCollapsed = val;
+	});
+
+	function toggleMaximize(val: boolean) {
+		isNotesMaximized.set(val);
+	}
+
+	function toggleSidebar(val: boolean) {
+		isNotesSidebarCollapsed.set(val);
+	}
 
 	const slug = $derived(page.params.slug);
 
@@ -121,7 +138,7 @@
 					<Button
 						variant="ghost"
 						size="icon"
-						onclick={() => (isLeftSidebarCollapsed = false)}
+						onclick={() => toggleSidebar(false)}
 						title={i18n.t('notes.expand_sidebar') || 'Expand Sidebar'}
 						class="size-8"
 					>
@@ -163,7 +180,7 @@
 				<Button
 					variant="ghost"
 					size="icon"
-					onclick={() => (isMaximized = false)}
+					onclick={() => toggleMaximize(false)}
 					title={i18n.t('window.restore') || 'Restore Window'}
 					class="size-8"
 				>
@@ -191,7 +208,7 @@
 						<Button
 							variant="ghost"
 							size="icon"
-							onclick={() => (isLeftSidebarCollapsed = true)}
+							onclick={() => toggleSidebar(true)}
 							title={i18n.t('notes.collapse_sidebar') || 'Collapse Sidebar'}
 							class="size-8 shrink-0"
 						>
@@ -322,7 +339,7 @@
 {:else}
 	<!-- Standard Window layout -->
 	<div class="container mx-auto flex h-[calc(100vh-8rem)] flex-col p-4">
-		<Window class="flex min-h-0 flex-grow flex-col overflow-hidden" {titlebarRight} childClassName="p-0" onMaximize={() => isMaximized = true} {isMaximized}>
+		<Window class="flex min-h-0 flex-grow flex-col overflow-hidden" {titlebarRight} childClassName="p-0" onMaximize={() => toggleMaximize(true)} {isMaximized}>
 			<div class="flex h-full flex-col divide-border overflow-hidden md:flex-row">
 				<!-- Sidebar -->
 				<div class="hidden h-full w-full flex-col overflow-hidden bg-muted/30 md:flex md:w-52 md:min-w-52">

--- a/src/routes/notes/[slug]/+page.svelte
+++ b/src/routes/notes/[slug]/+page.svelte
@@ -32,6 +32,7 @@
 		isLeftSidebarCollapsed = val;
 	});
 
+	// Use full width layout below the header (no outer margins/paddings)
 	function toggleMaximize(val: boolean) {
 		isNotesMaximized.set(val);
 	}
@@ -129,8 +130,8 @@
 {/snippet}
 
 {#if isMaximized}
-	<!-- Maximized layout (Covering full layout area below main header, no Window borders/shadows/padding) -->
-	<div class="fixed inset-x-0 bottom-0 top-[5.5rem] z-40 flex flex-col bg-background p-0 sm:px-16 pb-4">
+	<!-- Maximized layout (Covering full viewport below main header, no Window borders/shadows/padding) -->
+	<div class="fixed inset-x-0 bottom-0 top-[5.5rem] z-40 flex flex-col bg-background p-0 pb-4">
 		<!-- Toolbar for Maximized Mode -->
 		<div class="flex items-center justify-between border-b border-border bg-background px-4 py-2 sm:px-8 shrink-0">
 			<div class="flex items-center gap-2">

--- a/src/routes/notes/[slug]/+page.svelte
+++ b/src/routes/notes/[slug]/+page.svelte
@@ -1,57 +1,39 @@
 <script lang="ts">
-	import Window from '$lib/components/ui/window/window.svelte';
-	import { Heading } from '$lib/components/typography';
-	import { i18n } from '$lib/i18n/i18n.svelte';
-	import { onMount } from 'svelte';
-	import { FileText, Search, ArrowLeft, Tag, Calendar, List, ExternalLink, Github, PanelLeftClose, PanelLeftOpen, Minimize2 } from 'lucide-svelte';
-	import { PAGE_TITLE_SUFFIX } from '$lib/config';
 	import { page } from '$app/state';
-	import { MdSvelte } from '@jazzymcjazz/mdsvelte';
-	import { renderers } from '$lib/components/typography';
-	import { formatDate } from '$lib/utils/helper';
-	import { Toc } from '$lib/components/ui/toc';
-	import * as Popover from '$lib/components/ui/popover';
+	import NotesLayout from '../NotesLayout.svelte';
+	import { Heading, renderers } from '$lib/components/typography';
 	import { Button } from '$lib/components/ui/button';
-	import { isNotesMaximized, isNotesSidebarCollapsed } from '$lib/stores/notes';
+	import * as Popover from '$lib/components/ui/popover';
+	import { Toc } from '$lib/components/ui/toc';
+	import { PAGE_TITLE_SUFFIX } from '$lib/config';
+	import { i18n } from '$lib/i18n/i18n.svelte';
+	import { formatDate } from '$lib/utils/helper';
+	import { MdSvelte } from '@jazzymcjazz/mdsvelte';
+	import { ArrowLeft, Calendar, ExternalLink, Github, List, Tag } from 'lucide-svelte';
+	import { onMount } from 'svelte';
 
-	let notes = $state<any[]>([]);
-	let note = $state<any>(null);
+	type NoteListItem = { name: string };
+	type Note = {
+		title?: string;
+		content?: string;
+		date?: string;
+		tags?: string[];
+		githubUrl?: string;
+		webUrl?: string;
+	};
+
+	let notes = $state<NoteListItem[]>([]);
+	let note = $state<Note | null>(null);
 	let loadingList = $state(true);
 	let loadingNote = $state(true);
 	let searchQuery = $state('');
-
-	// Sync local component state with the shared notes store
-	let isMaximized = $state(false);
-	let isLeftSidebarCollapsed = $state(false);
-
-	isNotesMaximized.subscribe((val) => {
-		isMaximized = val;
-	});
-
-	isNotesSidebarCollapsed.subscribe((val) => {
-		isLeftSidebarCollapsed = val;
-	});
-
-	// Use full width layout below the header (no outer margins/paddings)
-	function toggleMaximize(val: boolean) {
-		isNotesMaximized.set(val);
-	}
-
-	function toggleSidebar(val: boolean) {
-		isNotesSidebarCollapsed.set(val);
-	}
-
 	const slug = $derived(page.params.slug);
 
 	async function fetchNote(currentSlug: string) {
 		loadingNote = true;
 		try {
 			const response = await fetch(`/api/notes/${currentSlug}`);
-			if (response.ok) {
-				note = await response.json();
-			} else {
-				note = null;
-			}
+			note = response.ok ? await response.json() : null;
 		} catch (error) {
 			console.error('Failed to fetch note:', error);
 			note = null;
@@ -61,39 +43,24 @@
 	}
 
 	onMount(async () => {
-		// Fetch notes list
 		try {
 			const response = await fetch('/api/notes');
-			if (response.ok) {
-				notes = await response.json();
-			}
+			if (response.ok) notes = await response.json();
 		} catch (error) {
 			console.error('Failed to fetch notes:', error);
 		} finally {
 			loadingList = false;
 		}
-
-		// Fetch current note
-		await fetchNote(slug);
 	});
 
 	$effect(() => {
-		if (slug) {
-			fetchNote(slug);
-		}
+		if (slug) fetchNote(slug);
 	});
 
-	const filteredNotes = $derived(
-		notes.filter((n) => n.name.toLowerCase().includes(searchQuery.toLowerCase()))
-	);
-
-	// Pre-processor for wikilinks [[link]] or [[link|text]]
 	function processContent(content: string) {
-		if (!content) return '';
 		return content.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_, link, text) => {
-			const label = text || link;
 			const href = `/notes/${link.trim().replace(/\s+/g, '-')}`;
-			return `[${label}](${href})`;
+			return `[${text || link}](${href})`;
 		});
 	}
 
@@ -104,407 +71,86 @@
 	<title>{note?.title || slug}{PAGE_TITLE_SUFFIX}</title>
 </svelte:head>
 
-{#snippet titlebarRight()}
-	<Button
-		variant="ghost"
-		size="icon"
-		href={note?.githubUrl}
-		target="_blank"
-		rel="noopener"
-		disabled={!note?.githubUrl}
-		title={i18n.t('notes.view_on_github') || 'View on GitHub'}
-	>
+{#snippet noteActions()}
+	<Button variant="ghost" size="icon" href={note?.githubUrl} target="_blank" rel="noopener" disabled={!note?.githubUrl} title={i18n.t('notes.view_on_github') || 'View on GitHub'}>
 		<Github class="size-4" />
 	</Button>
-	<Button
-		variant="ghost"
-		size="icon"
-		href={note?.webUrl}
-		target="_blank"
-		rel="noopener"
-		disabled={!note?.webUrl}
-		title={i18n.t('notes.view_on_web') || 'View on Website'}
-	>
+	<Button variant="ghost" size="icon" href={note?.webUrl} target="_blank" rel="noopener" disabled={!note?.webUrl} title={i18n.t('notes.view_on_web') || 'View on Website'}>
 		<ExternalLink class="size-4" />
 	</Button>
 {/snippet}
 
-{#if isMaximized}
-	<!-- Maximized layout (Covering full viewport below main header, no Window borders/shadows/padding) -->
-	<div class="fixed inset-x-0 bottom-0 top-[5.5rem] z-40 flex flex-col bg-background p-0 pb-4">
-		<!-- Toolbar for Maximized Mode -->
-		<div class="flex items-center justify-between border-b border-border bg-background px-4 py-2 sm:px-8 shrink-0">
-			<div class="flex items-center gap-2">
-				{#if isLeftSidebarCollapsed}
-					<Button
-						variant="ghost"
-						size="icon"
-						onclick={() => toggleSidebar(false)}
-						title={i18n.t('notes.expand_sidebar') || 'Expand Sidebar'}
-						class="hidden md:inline-flex size-8"
-					>
-						<PanelLeftOpen class="size-5" />
-					</Button>
-				{:else}
-					<Button
-						variant="ghost"
-						size="icon"
-						onclick={() => toggleSidebar(true)}
-						title={i18n.t('notes.collapse_sidebar') || 'Collapse Sidebar'}
-						class="hidden md:inline-flex size-8"
-					>
-						<PanelLeftClose class="size-5" />
-					</Button>
-				{/if}
-				<span class="text-sm font-semibold tracking-tight text-muted-foreground">
-					{note?.title || slug}
-				</span>
-			</div>
-			<div class="flex items-center gap-2">
-				<!-- GitHub/Web Actions inside minimized view inside toolbar -->
-				<Button
-					variant="ghost"
-					size="icon"
-					href={note?.githubUrl}
-					target="_blank"
-					rel="noopener"
-					disabled={!note?.githubUrl}
-					title={i18n.t('notes.view_on_github') || 'View on GitHub'}
-					class="size-8"
-				>
-					<Github class="size-4" />
-				</Button>
-				<Button
-					variant="ghost"
-					size="icon"
-					href={note?.webUrl}
-					target="_blank"
-					rel="noopener"
-					disabled={!note?.webUrl}
-					title={i18n.t('notes.view_on_web') || 'View on Website'}
-					class="size-8"
-				>
-					<ExternalLink class="size-4" />
-				</Button>
-				<div class="h-4 w-[1px] bg-border mx-1"></div>
-				<!-- Restore Button -->
-				<Button
-					variant="ghost"
-					size="icon"
-					onclick={() => toggleMaximize(false)}
-					title={i18n.t('window.restore') || 'Restore Window'}
-					class="size-8"
-				>
-					<Minimize2 class="size-5" />
-				</Button>
-			</div>
-		</div>
-
-		<!-- Inner maximized container -->
-		<div class="flex flex-grow min-h-0 overflow-hidden divide-x divide-border">
-			<!-- Sidebar -->
-			{#if !isLeftSidebarCollapsed}
-				<div class="hidden h-full w-full flex-col overflow-hidden bg-muted/30 md:flex md:w-64 md:min-w-64">
-					<div class="shrink-0 border-b border-border p-4">
-						<div class="relative flex-grow">
-							<Search class="absolute left-2 top-2.5 size-4 text-muted-foreground" />
-							<input
-								type="text"
-								placeholder={i18n.t('notes.search_placeholder') || 'Search notes...'}
-								bind:value={searchQuery}
-								class="w-full rounded-md border border-border bg-background py-2 pl-8 pr-4 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
-							/>
+<NotesLayout
+	{notes}
+	loading={loadingList}
+	activeSlug={slug}
+	title={note?.title || slug}
+	bind:searchQuery
+	collapsibleSidebar
+	titlebarRight={noteActions}
+	toolbarActions={noteActions}
+>
+	<div class="flex h-full flex-grow flex-col overflow-hidden bg-background lg:flex-row">
+		<div id="notes-content-area" class="flex-grow overflow-y-auto p-4 md:p-8">
+			<div class="mx-auto w-full max-w-3xl">
+				{#if loadingNote}
+					<div class="flex h-64 items-center justify-center">
+						<div class="h-8 w-8 animate-spin rounded-full border-b-2 border-primary"></div>
+					</div>
+				{:else if note}
+					<div class="mb-8">
+						<div class="mb-4 flex items-center justify-between gap-4">
+							<a href="/notes" class="flex items-center gap-1 text-primary hover:underline md:hidden">
+								<ArrowLeft class="size-4" />
+								{i18n.t('notes.back_to_list') || 'Back'}
+							</a>
+							<div class="lg:hidden">
+								<Popover.Root>
+									<Popover.Trigger asChild>
+										{#snippet child({ props })}<Button variant="ghost" size="icon" {...props}><List class="size-4" /></Button>{/snippet}
+									</Popover.Trigger>
+									<Popover.Content class="w-64 p-4">
+										<Toc selector=".prose" rootSelector="#notes-content-area" content={processedContent} />
+									</Popover.Content>
+								</Popover.Root>
+							</div>
 						</div>
-					</div>
-					<div class="flex-grow overflow-y-auto">
-						{#if loadingList}
-							<div class="p-4 text-center text-muted-foreground">
-								{i18n.t('common.loading') || 'Loading...'}
-							</div>
-						{:else}
-							<ul class="divide-y divide-border/50">
-								{#each filteredNotes as n}
-									<li>
-										<a
-											href="/notes/{n.name}"
-											class="flex items-center gap-3 p-4 transition-colors hover:bg-muted {n.name ===
-											slug
-												? 'border-r-2 border-primary bg-muted'
-												: ''}"
-										>
-											<FileText
-												class="size-4 {n.name === slug ? 'text-primary' : 'text-muted-foreground'}"
-											/>
-											<span
-												class="truncate text-sm font-medium {n.name === slug ? 'text-primary' : ''}"
-												>{n.name}</span
-											>
-										</a>
-									</li>
-								{/each}
-							</ul>
-						{/if}
-					</div>
-				</div>
-			{/if}
-
-			<!-- Main Panel -->
-			<div class="flex h-full flex-grow flex-col overflow-hidden lg:flex-row bg-background">
-				<div id="notes-content-area" class="flex-grow overflow-y-auto p-4 md:p-8">
-					<div class="mx-auto w-full max-w-3xl">
-						{#if loadingNote}
-							<div class="flex h-64 items-center justify-center">
-								<div class="h-8 w-8 animate-spin rounded-full border-b-2 border-primary"></div>
-							</div>
-						{:else if note}
-							<div class="mb-8">
-								<div class="mb-4 flex items-center justify-between gap-4">
-									<a
-										href="/notes"
-										class="flex items-center gap-1 text-primary hover:underline md:hidden"
-									>
-										<ArrowLeft class="size-4" />
-										{i18n.t('notes.back_to_list') || 'Back'}
-									</a>
-
-									<!-- Mobile TOC Trigger -->
-									<div class="lg:hidden">
-										<Popover.Root>
-											<Popover.Trigger asChild>
-												{#snippet child({ props })}
-													<Button variant="ghost" size="icon" {...props}>
-														<List class="size-4" />
-													</Button>
-												{/snippet}
-											</Popover.Trigger>
-											<Popover.Content class="w-64 p-4">
-												<Toc
-													selector=".prose"
-													rootSelector="#notes-content-area"
-													content={processedContent}
-												/>
-											</Popover.Content>
-										</Popover.Root>
-									</div>
-								</div>
-								<div class="flex flex-wrap gap-4 text-sm text-muted-foreground">
-									{#if note.date}
-										<div class="flex items-center gap-1">
-											<Calendar class="size-4" />
-											{formatDate(note.date)}
-										</div>
-									{/if}
-									{#if note.tags && note.tags.length > 0}
-										<div class="flex items-center gap-1">
-											<Tag class="size-4" />
-											<div class="flex gap-2">
-												{#each note.tags as tag}
-													<span class="rounded-md bg-muted px-2 py-0.5">{tag}</span>
-												{/each}
-											</div>
-										</div>
-									{/if}
-								</div>
-							</div>
-							<div
-								class="prose dark:prose-invert mb-12 max-w-none font-mono text-sm leading-relaxed"
-							>
-								<MdSvelte source={processedContent} {renderers} />
-							</div>
-						{:else}
-							<div class="py-12 text-center">
-								<Heading depth={2} class="mb-4"
-									>{i18n.t('notes.not_found') || 'Note not found'}</Heading
-								>
-								<p class="mb-8">
-									{i18n.t('notes.not_found_desc') || 'The requested note could not be loaded.'}
-								</p>
-								<a href="/notes" class="text-primary hover:underline"
-									>{i18n.t('notes.back_to_list') || 'Return to overview'}</a
-								>
-							</div>
-						{/if}
-					</div>
-				</div>
-				<!-- TOC Sidebar (Desktop only) -->
-				{#if note && !loadingNote}
-					<aside
-						class="hidden h-full w-56 shrink-0 overflow-y-auto border-l border-border p-8 lg:block bg-background"
-					>
-						<Toc selector=".prose" rootSelector="#notes-content-area" content={processedContent} />
-					</aside>
-				{/if}
-			</div>
-		</div>
-	</div>
-{:else}
-	<!-- Standard Window layout -->
-	<div class="container mx-auto flex h-[calc(100vh-8rem)] flex-col p-4">
-		<Window class="flex min-h-0 flex-grow flex-col overflow-hidden" {titlebarRight} childClassName="p-0" onMaximize={() => toggleMaximize(true)} {isMaximized}>
-			<div class="flex h-full flex-col divide-border overflow-hidden md:flex-row">
-				<!-- Sidebar -->
-				<div class="hidden h-full w-full flex-col overflow-hidden bg-muted/30 md:flex md:w-52 md:min-w-52">
-					<div class="shrink-0 border-b border-border p-4">
-						<div class="relative flex-grow">
-							<Search class="absolute left-2 top-2.5 size-4 text-muted-foreground" />
-							<input
-								type="text"
-								placeholder={i18n.t('notes.search_placeholder') || 'Search notes...'}
-								bind:value={searchQuery}
-								class="w-full rounded-md border border-border bg-background py-2 pl-8 pr-4 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
-							/>
-						</div>
-					</div>
-					<div class="flex-grow overflow-y-auto">
-						{#if loadingList}
-							<div class="p-4 text-center text-muted-foreground">
-								{i18n.t('common.loading') || 'Loading...'}
-							</div>
-						{:else}
-							<ul class="divide-y divide-border/50">
-								{#each filteredNotes as n}
-									<li>
-										<a
-											href="/notes/{n.name}"
-											class="flex items-center gap-3 p-4 transition-colors hover:bg-muted {n.name ===
-											slug
-												? 'border-r-2 border-primary bg-muted'
-												: ''}"
-										>
-											<FileText
-												class="size-4 {n.name === slug ? 'text-primary' : 'text-muted-foreground'}"
-											/>
-											<span
-												class="truncate text-sm font-medium {n.name === slug ? 'text-primary' : ''}"
-												>{n.name}</span
-											>
-										</a>
-									</li>
-								{/each}
-							</ul>
-						{/if}
-					</div>
-				</div>
-
-				<!-- Main Panel -->
-				<div class="flex h-full flex-grow flex-col overflow-hidden lg:flex-row">
-					<div id="notes-content-area" class="flex-grow overflow-y-auto p-4 md:p-8">
-						<div class="mx-auto w-full max-w-3xl">
-							{#if loadingNote}
-								<div class="flex h-64 items-center justify-center">
-									<div class="h-8 w-8 animate-spin rounded-full border-b-2 border-primary"></div>
-								</div>
-							{:else if note}
-								<div class="mb-8">
-									<div class="mb-4 flex items-center justify-between gap-4">
-										<a
-											href="/notes"
-											class="flex items-center gap-1 text-primary hover:underline md:hidden"
-										>
-											<ArrowLeft class="size-4" />
-											{i18n.t('notes.back_to_list') || 'Back'}
-										</a>
-
-										<!-- Mobile TOC Trigger -->
-										<div class="lg:hidden">
-											<Popover.Root>
-												<Popover.Trigger asChild>
-													{#snippet child({ props })}
-														<Button variant="ghost" size="icon" {...props}>
-															<List class="size-4" />
-														</Button>
-													{/snippet}
-												</Popover.Trigger>
-												<Popover.Content class="w-64 p-4">
-													<Toc
-														selector=".prose"
-														rootSelector="#notes-content-area"
-														content={processedContent}
-													/>
-												</Popover.Content>
-											</Popover.Root>
-										</div>
-									</div>
-									<div class="flex flex-wrap gap-4 text-sm text-muted-foreground">
-										{#if note.date}
-											<div class="flex items-center gap-1">
-												<Calendar class="size-4" />
-												{formatDate(note.date)}
-											</div>
-										{/if}
-										{#if note.tags && note.tags.length > 0}
-											<div class="flex items-center gap-1">
-												<Tag class="size-4" />
-												<div class="flex gap-2">
-													{#each note.tags as tag}
-														<span class="rounded-md bg-muted px-2 py-0.5">{tag}</span>
-													{/each}
-												</div>
-											</div>
-										{/if}
-									</div>
-								</div>
-								<div
-									class="prose dark:prose-invert mb-12 max-w-none font-mono text-sm leading-relaxed"
-								>
-									<MdSvelte source={processedContent} {renderers} />
-								</div>
-							{:else}
-								<div class="py-12 text-center">
-									<Heading depth={2} class="mb-4"
-										>{i18n.t('notes.not_found') || 'Note not found'}</Heading
-									>
-									<p class="mb-8">
-										{i18n.t('notes.not_found_desc') || 'The requested note could not be loaded.'}
-									</p>
-									<a href="/notes" class="text-primary hover:underline"
-										>{i18n.t('notes.back_to_list') || 'Return to overview'}</a
-									>
+						<div class="flex flex-wrap gap-4 text-sm text-muted-foreground">
+							{#if note.date}<div class="flex items-center gap-1"><Calendar class="size-4" />{formatDate(note.date)}</div>{/if}
+							{#if note.tags?.length}
+								<div class="flex items-center gap-1">
+									<Tag class="size-4" />
+									<div class="flex gap-2">{#each note.tags as tag}<span class="rounded-md bg-muted px-2 py-0.5">{tag}</span>{/each}</div>
 								</div>
 							{/if}
 						</div>
 					</div>
-					<!-- TOC Sidebar (Desktop only) -->
-					{#if note && !loadingNote}
-						<aside
-							class="hidden h-full w-56 shrink-0 overflow-y-auto border-l border-border p-8 lg:block"
-						>
-							<Toc selector=".prose" rootSelector="#notes-content-area" content={processedContent} />
-						</aside>
-					{/if}
-				</div>
+					<div class="prose dark:prose-invert mb-12 max-w-none font-mono text-sm leading-relaxed">
+						<MdSvelte source={processedContent} {renderers} />
+					</div>
+				{:else}
+					<div class="py-12 text-center">
+						<Heading depth={2} class="mb-4">{i18n.t('notes.not_found') || 'Note not found'}</Heading>
+						<p class="mb-8">{i18n.t('notes.not_found_desc') || 'The requested note could not be loaded.'}</p>
+						<a href="/notes" class="text-primary hover:underline">{i18n.t('notes.back_to_list') || 'Return to overview'}</a>
+					</div>
+				{/if}
 			</div>
-		</Window>
+		</div>
+		{#if note && !loadingNote}
+			<aside class="hidden h-full w-56 shrink-0 overflow-y-auto border-l border-border bg-background p-8 lg:block">
+				<Toc selector=".prose" rootSelector="#notes-content-area" content={processedContent} />
+			</aside>
+		{/if}
 	</div>
-{/if}
+</NotesLayout>
 
 <style>
-	:global(.prose a) {
-		color: hsl(var(--primary));
-		text-decoration: underline;
-		text-underline-offset: 4px;
-	}
-	:global(.prose a:hover) {
-		opacity: 0.8;
-	}
-	:global(.prose h1, .prose h2, .prose h3) {
-		scroll-margin-top: 2rem;
-	}
-	:global(.prose table) {
-		width: 100%;
-		border-collapse: collapse;
-		margin: 1.5rem 0;
-	}
-	:global(.prose th, .prose td) {
-		border: 1px solid hsl(var(--border));
-		padding: 0.5rem 0.75rem;
-		text-align: left;
-	}
-	:global(.prose th) {
-		background-color: hsl(var(--muted) / 0.5);
-		font-weight: 600;
-	}
-	:global(.prose tr:nth-child(even)) {
-		background-color: hsl(var(--muted) / 0.2);
-	}
+	:global(.prose a) { color: hsl(var(--primary)); text-decoration: underline; text-underline-offset: 4px; }
+	:global(.prose a:hover) { opacity: 0.8; }
+	:global(.prose h1, .prose h2, .prose h3) { scroll-margin-top: 2rem; }
+	:global(.prose table) { width: 100%; border-collapse: collapse; margin: 1.5rem 0; }
+	:global(.prose th, .prose td) { border: 1px solid hsl(var(--border)); padding: 0.5rem 0.75rem; text-align: left; }
+	:global(.prose th) { background-color: hsl(var(--muted) / 0.5); font-weight: 600; }
+	:global(.prose tr:nth-child(even)) { background-color: hsl(var(--muted) / 0.2); }
 </style>

--- a/src/routes/notes/[slug]/+page.svelte
+++ b/src/routes/notes/[slug]/+page.svelte
@@ -3,7 +3,7 @@
 	import { Heading } from '$lib/components/typography';
 	import { i18n } from '$lib/i18n/i18n.svelte';
 	import { onMount } from 'svelte';
-	import { FileText, Search, ArrowLeft, Tag, Calendar, List, ExternalLink, Github } from 'lucide-svelte';
+	import { FileText, Search, ArrowLeft, Tag, Calendar, List, ExternalLink, Github, PanelLeftClose, PanelLeftOpen, Minimize2 } from 'lucide-svelte';
 	import { PAGE_TITLE_SUFFIX } from '$lib/config';
 	import { page } from '$app/state';
 	import { MdSvelte } from '@jazzymcjazz/mdsvelte';
@@ -18,6 +18,10 @@
 	let loadingList = $state(true);
 	let loadingNote = $state(true);
 	let searchQuery = $state('');
+
+	// State for maximized view and collapsible sidebar
+	let isMaximized = $state(false);
+	let isLeftSidebarCollapsed = $state(false);
 
 	const slug = $derived(page.params.slug);
 
@@ -107,55 +111,127 @@
 	</Button>
 {/snippet}
 
-<div class="container mx-auto flex h-[calc(100vh-8rem)] flex-col p-4">
-	<Window class="flex min-h-0 flex-grow flex-col overflow-hidden" {titlebarRight} childClassName="p-0">
-		<div class="flex h-full flex-col divide-border overflow-hidden md:flex-row">
+{#if isMaximized}
+	<!-- Maximized layout (Covering full layout area below main header, no Window borders/shadows/padding) -->
+	<div class="fixed inset-x-0 bottom-0 top-[5.5rem] z-40 flex flex-col bg-background p-0 sm:px-16 pb-4">
+		<!-- Toolbar for Maximized Mode -->
+		<div class="flex items-center justify-between border-b border-border bg-background px-4 py-2 sm:px-8 shrink-0">
+			<div class="flex items-center gap-2">
+				{#if isLeftSidebarCollapsed}
+					<Button
+						variant="ghost"
+						size="icon"
+						onclick={() => (isLeftSidebarCollapsed = false)}
+						title={i18n.t('notes.expand_sidebar') || 'Expand Sidebar'}
+						class="size-8"
+					>
+						<PanelLeftOpen class="size-5" />
+					</Button>
+				{/if}
+				<span class="text-sm font-semibold tracking-tight text-muted-foreground">
+					{note?.title || slug}
+				</span>
+			</div>
+			<div class="flex items-center gap-2">
+				<!-- GitHub/Web Actions inside minimized view inside toolbar -->
+				<Button
+					variant="ghost"
+					size="icon"
+					href={note?.githubUrl}
+					target="_blank"
+					rel="noopener"
+					disabled={!note?.githubUrl}
+					title={i18n.t('notes.view_on_github') || 'View on GitHub'}
+					class="size-8"
+				>
+					<Github class="size-4" />
+				</Button>
+				<Button
+					variant="ghost"
+					size="icon"
+					href={note?.webUrl}
+					target="_blank"
+					rel="noopener"
+					disabled={!note?.webUrl}
+					title={i18n.t('notes.view_on_web') || 'View on Website'}
+					class="size-8"
+				>
+					<ExternalLink class="size-4" />
+				</Button>
+				<div class="h-4 w-[1px] bg-border mx-1"></div>
+				<!-- Restore Button -->
+				<Button
+					variant="ghost"
+					size="icon"
+					onclick={() => (isMaximized = false)}
+					title={i18n.t('window.restore') || 'Restore Window'}
+					class="size-8"
+				>
+					<Minimize2 class="size-5" />
+				</Button>
+			</div>
+		</div>
+
+		<!-- Inner maximized container -->
+		<div class="flex flex-grow min-h-0 overflow-hidden divide-x divide-border">
 			<!-- Sidebar -->
-			<div class="hidden h-full w-full flex-col overflow-hidden bg-muted/30 md:flex md:w-52 md:min-w-52">
-				<div class="shrink-0 border-b border-border p-4">
-					<div class="relative flex-grow">
-						<Search class="absolute left-2 top-2.5 size-4 text-muted-foreground" />
-						<input
-							type="text"
-							placeholder={i18n.t('notes.search_placeholder') || 'Search notes...'}
-							bind:value={searchQuery}
-							class="w-full rounded-md border border-border bg-background py-2 pl-8 pr-4 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
-						/>
+			{#if !isLeftSidebarCollapsed}
+				<div class="hidden h-full w-full flex-col overflow-hidden bg-muted/30 md:flex md:w-64 md:min-w-64">
+					<div class="shrink-0 border-b border-border p-4 flex items-center justify-between gap-2">
+						<div class="relative flex-grow">
+							<Search class="absolute left-2 top-2.5 size-4 text-muted-foreground" />
+							<input
+								type="text"
+								placeholder={i18n.t('notes.search_placeholder') || 'Search notes...'}
+								bind:value={searchQuery}
+								class="w-full rounded-md border border-border bg-background py-2 pl-8 pr-4 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+							/>
+						</div>
+						<!-- Collapse Sidebar Button -->
+						<Button
+							variant="ghost"
+							size="icon"
+							onclick={() => (isLeftSidebarCollapsed = true)}
+							title={i18n.t('notes.collapse_sidebar') || 'Collapse Sidebar'}
+							class="size-8 shrink-0"
+						>
+							<PanelLeftClose class="size-5" />
+						</Button>
+					</div>
+					<div class="flex-grow overflow-y-auto">
+						{#if loadingList}
+							<div class="p-4 text-center text-muted-foreground">
+								{i18n.t('common.loading') || 'Loading...'}
+							</div>
+						{:else}
+							<ul class="divide-y divide-border/50">
+								{#each filteredNotes as n}
+									<li>
+										<a
+											href="/notes/{n.name}"
+											class="flex items-center gap-3 p-4 transition-colors hover:bg-muted {n.name ===
+											slug
+												? 'border-r-2 border-primary bg-muted'
+												: ''}"
+										>
+											<FileText
+												class="size-4 {n.name === slug ? 'text-primary' : 'text-muted-foreground'}"
+											/>
+											<span
+												class="truncate text-sm font-medium {n.name === slug ? 'text-primary' : ''}"
+												>{n.name}</span
+											>
+										</a>
+									</li>
+								{/each}
+							</ul>
+						{/if}
 					</div>
 				</div>
-				<div class="flex-grow overflow-y-auto">
-					{#if loadingList}
-						<div class="p-4 text-center text-muted-foreground">
-							{i18n.t('common.loading') || 'Loading...'}
-						</div>
-					{:else}
-						<ul class="divide-y divide-border/50">
-							{#each filteredNotes as n}
-								<li>
-									<a
-										href="/notes/{n.name}"
-										class="flex items-center gap-3 p-4 transition-colors hover:bg-muted {n.name ===
-										slug
-											? 'border-r-2 border-primary bg-muted'
-											: ''}"
-									>
-										<FileText
-											class="size-4 {n.name === slug ? 'text-primary' : 'text-muted-foreground'}"
-										/>
-										<span
-											class="truncate text-sm font-medium {n.name === slug ? 'text-primary' : ''}"
-											>{n.name}</span
-										>
-									</a>
-								</li>
-							{/each}
-						</ul>
-					{/if}
-				</div>
-			</div>
+			{/if}
 
 			<!-- Main Panel -->
-			<div class="flex h-full flex-grow flex-col overflow-hidden lg:flex-row">
+			<div class="flex h-full flex-grow flex-col overflow-hidden lg:flex-row bg-background">
 				<div id="notes-content-area" class="flex-grow overflow-y-auto p-4 md:p-8">
 					<div class="mx-auto w-full max-w-3xl">
 						{#if loadingNote}
@@ -235,15 +311,154 @@
 				<!-- TOC Sidebar (Desktop only) -->
 				{#if note && !loadingNote}
 					<aside
-						class="hidden h-full w-56 shrink-0 overflow-y-auto border-l border-border p-8 lg:block"
+						class="hidden h-full w-56 shrink-0 overflow-y-auto border-l border-border p-8 lg:block bg-background"
 					>
 						<Toc selector=".prose" rootSelector="#notes-content-area" content={processedContent} />
 					</aside>
 				{/if}
 			</div>
 		</div>
-	</Window>
-</div>
+	</div>
+{:else}
+	<!-- Standard Window layout -->
+	<div class="container mx-auto flex h-[calc(100vh-8rem)] flex-col p-4">
+		<Window class="flex min-h-0 flex-grow flex-col overflow-hidden" {titlebarRight} childClassName="p-0" onMaximize={() => isMaximized = true} {isMaximized}>
+			<div class="flex h-full flex-col divide-border overflow-hidden md:flex-row">
+				<!-- Sidebar -->
+				<div class="hidden h-full w-full flex-col overflow-hidden bg-muted/30 md:flex md:w-52 md:min-w-52">
+					<div class="shrink-0 border-b border-border p-4">
+						<div class="relative flex-grow">
+							<Search class="absolute left-2 top-2.5 size-4 text-muted-foreground" />
+							<input
+								type="text"
+								placeholder={i18n.t('notes.search_placeholder') || 'Search notes...'}
+								bind:value={searchQuery}
+								class="w-full rounded-md border border-border bg-background py-2 pl-8 pr-4 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+							/>
+						</div>
+					</div>
+					<div class="flex-grow overflow-y-auto">
+						{#if loadingList}
+							<div class="p-4 text-center text-muted-foreground">
+								{i18n.t('common.loading') || 'Loading...'}
+							</div>
+						{:else}
+							<ul class="divide-y divide-border/50">
+								{#each filteredNotes as n}
+									<li>
+										<a
+											href="/notes/{n.name}"
+											class="flex items-center gap-3 p-4 transition-colors hover:bg-muted {n.name ===
+											slug
+												? 'border-r-2 border-primary bg-muted'
+												: ''}"
+										>
+											<FileText
+												class="size-4 {n.name === slug ? 'text-primary' : 'text-muted-foreground'}"
+											/>
+											<span
+												class="truncate text-sm font-medium {n.name === slug ? 'text-primary' : ''}"
+												>{n.name}</span
+											>
+										</a>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+					</div>
+				</div>
+
+				<!-- Main Panel -->
+				<div class="flex h-full flex-grow flex-col overflow-hidden lg:flex-row">
+					<div id="notes-content-area" class="flex-grow overflow-y-auto p-4 md:p-8">
+						<div class="mx-auto w-full max-w-3xl">
+							{#if loadingNote}
+								<div class="flex h-64 items-center justify-center">
+									<div class="h-8 w-8 animate-spin rounded-full border-b-2 border-primary"></div>
+								</div>
+							{:else if note}
+								<div class="mb-8">
+									<div class="mb-4 flex items-center justify-between gap-4">
+										<a
+											href="/notes"
+											class="flex items-center gap-1 text-primary hover:underline md:hidden"
+										>
+											<ArrowLeft class="size-4" />
+											{i18n.t('notes.back_to_list') || 'Back'}
+										</a>
+
+										<!-- Mobile TOC Trigger -->
+										<div class="lg:hidden">
+											<Popover.Root>
+												<Popover.Trigger asChild>
+													{#snippet child({ props })}
+														<Button variant="ghost" size="icon" {...props}>
+															<List class="size-4" />
+														</Button>
+													{/snippet}
+												</Popover.Trigger>
+												<Popover.Content class="w-64 p-4">
+													<Toc
+														selector=".prose"
+														rootSelector="#notes-content-area"
+														content={processedContent}
+													/>
+												</Popover.Content>
+											</Popover.Root>
+										</div>
+									</div>
+									<div class="flex flex-wrap gap-4 text-sm text-muted-foreground">
+										{#if note.date}
+											<div class="flex items-center gap-1">
+												<Calendar class="size-4" />
+												{formatDate(note.date)}
+											</div>
+										{/if}
+										{#if note.tags && note.tags.length > 0}
+											<div class="flex items-center gap-1">
+												<Tag class="size-4" />
+												<div class="flex gap-2">
+													{#each note.tags as tag}
+														<span class="rounded-md bg-muted px-2 py-0.5">{tag}</span>
+													{/each}
+												</div>
+											</div>
+										{/if}
+									</div>
+								</div>
+								<div
+									class="prose dark:prose-invert mb-12 max-w-none font-mono text-sm leading-relaxed"
+								>
+									<MdSvelte source={processedContent} {renderers} />
+								</div>
+							{:else}
+								<div class="py-12 text-center">
+									<Heading depth={2} class="mb-4"
+										>{i18n.t('notes.not_found') || 'Note not found'}</Heading
+									>
+									<p class="mb-8">
+										{i18n.t('notes.not_found_desc') || 'The requested note could not be loaded.'}
+									</p>
+									<a href="/notes" class="text-primary hover:underline"
+										>{i18n.t('notes.back_to_list') || 'Return to overview'}</a
+									>
+								</div>
+							{/if}
+						</div>
+					</div>
+					<!-- TOC Sidebar (Desktop only) -->
+					{#if note && !loadingNote}
+						<aside
+							class="hidden h-full w-56 shrink-0 overflow-y-auto border-l border-border p-8 lg:block"
+						>
+							<Toc selector=".prose" rootSelector="#notes-content-area" content={processedContent} />
+						</aside>
+					{/if}
+				</div>
+			</div>
+		</Window>
+	</div>
+{/if}
 
 <style>
 	:global(.prose a) {

--- a/src/routes/notes/[slug]/+page.svelte
+++ b/src/routes/notes/[slug]/+page.svelte
@@ -141,7 +141,7 @@
 						size="icon"
 						onclick={() => toggleSidebar(false)}
 						title={i18n.t('notes.expand_sidebar') || 'Expand Sidebar'}
-						class="size-8"
+						class="hidden md:inline-flex size-8"
 					>
 						<PanelLeftOpen class="size-5" />
 					</Button>
@@ -151,7 +151,7 @@
 						size="icon"
 						onclick={() => toggleSidebar(true)}
 						title={i18n.t('notes.collapse_sidebar') || 'Collapse Sidebar'}
-						class="size-8"
+						class="hidden md:inline-flex size-8"
 					>
 						<PanelLeftClose class="size-5" />
 					</Button>

--- a/src/routes/notes/[slug]/+page.svelte
+++ b/src/routes/notes/[slug]/+page.svelte
@@ -145,6 +145,16 @@
 					>
 						<PanelLeftOpen class="size-5" />
 					</Button>
+				{:else}
+					<Button
+						variant="ghost"
+						size="icon"
+						onclick={() => toggleSidebar(true)}
+						title={i18n.t('notes.collapse_sidebar') || 'Collapse Sidebar'}
+						class="size-8"
+					>
+						<PanelLeftClose class="size-5" />
+					</Button>
 				{/if}
 				<span class="text-sm font-semibold tracking-tight text-muted-foreground">
 					{note?.title || slug}
@@ -195,7 +205,7 @@
 			<!-- Sidebar -->
 			{#if !isLeftSidebarCollapsed}
 				<div class="hidden h-full w-full flex-col overflow-hidden bg-muted/30 md:flex md:w-64 md:min-w-64">
-					<div class="shrink-0 border-b border-border p-4 flex items-center justify-between gap-2">
+					<div class="shrink-0 border-b border-border p-4">
 						<div class="relative flex-grow">
 							<Search class="absolute left-2 top-2.5 size-4 text-muted-foreground" />
 							<input
@@ -205,16 +215,6 @@
 								class="w-full rounded-md border border-border bg-background py-2 pl-8 pr-4 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
 							/>
 						</div>
-						<!-- Collapse Sidebar Button -->
-						<Button
-							variant="ghost"
-							size="icon"
-							onclick={() => toggleSidebar(true)}
-							title={i18n.t('notes.collapse_sidebar') || 'Collapse Sidebar'}
-							class="size-8 shrink-0"
-						>
-							<PanelLeftClose class="size-5" />
-						</Button>
 					</div>
 					<div class="flex-grow overflow-y-auto">
 						{#if loadingList}


### PR DESCRIPTION
Implemented notes view maximization via the window maximize action. When maximized, the standard window borders and shadows disappear, giving full available space below the header. Added a collapsible left sidebar in this maximized view with custom collapse and expand toggles in the toolbars.

---
*PR created automatically by Jules for task [10487858200073015391](https://jules.google.com/task/10487858200073015391) started by @dnnsmnstrr*