### PR TITLE
Add missing utility and cache tests

### DIFF
--- a/src/lib/server/cache.test.ts
+++ b/src/lib/server/cache.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { gistCache } from './cache';
+
+describe('gistCache', () => {
+	beforeEach(() => {
+		gistCache.clear();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+	});
+
+	afterEach(() => {
+		gistCache.clear();
+		vi.useRealTimers();
+	});
+
+	it('returns a stored value before its TTL expires', () => {
+		gistCache.set('now', { status: 'online' }, 60);
+		vi.advanceTimersByTime(59_999);
+
+		expect(gistCache.get('now')).toEqual({ status: 'online' });
+	});
+
+	it('evicts a stored value after its TTL expires', () => {
+		gistCache.set('now', { status: 'online' }, 60);
+		vi.advanceTimersByTime(60_001);
+
+		expect(gistCache.get('now')).toBeNull();
+	});
+
+	it('deletes one entry without affecting another', () => {
+		gistCache.set('now', { value: 1 }, 60);
+		gistCache.set('projects', { value: 2 }, 60);
+
+		gistCache.delete('now');
+
+		expect(gistCache.get('now')).toBeNull();
+		expect(gistCache.get('projects')).toEqual({ value: 2 });
+	});
+
+	it('clears all entries', () => {
+		gistCache.set('now', { value: 1 }, 60);
+		gistCache.set('projects', { value: 2 }, 60);
+
+		gistCache.clear();
+
+		expect(gistCache.get('now')).toBeNull();
+		expect(gistCache.get('projects')).toBeNull();
+	});
+});

--- a/src/lib/utils/api.test.ts
+++ b/src/lib/utils/api.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/i18n/i18n.svelte', () => ({
+	i18n: { lang: 'en' }
+}));
+
+import { searchData, sortData } from './api';
+
+describe('API data utilities', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe('sortData', () => {
+		it('sorts strings without mutating the source array', () => {
+			const items = [{ title: 'Zulu' }, { title: 'Alpha' }];
+
+			expect(sortData(items, 'title')).toEqual([{ title: 'Alpha' }, { title: 'Zulu' }]);
+			expect(items).toEqual([{ title: 'Zulu' }, { title: 'Alpha' }]);
+		});
+
+		it('sorts valid dates chronologically rather than lexicographically', () => {
+			const items = [{ date: '2025-12-01' }, { date: '2026-01-02' }, { date: '2025-03-10' }];
+
+			expect(sortData(items, 'date', 'desc').map(({ date }) => date)).toEqual([
+				'2026-01-02',
+				'2025-12-01',
+				'2025-03-10'
+			]);
+		});
+
+		it('places missing values last in both directions', () => {
+			const items = [{ title: undefined }, { title: 'Beta' }, { title: 'Alpha' }];
+
+			expect(sortData(items, 'title', 'asc').at(-1)?.title).toBeUndefined();
+			expect(sortData(items, 'title', 'desc').at(-1)?.title).toBeUndefined();
+		});
+
+		it('sorts numeric values in either direction', () => {
+			const items = [{ rank: 2 }, { rank: 10 }, { rank: 1 }];
+
+			expect(sortData(items as any[], 'rank' as any, 'asc').map((item: any) => item.rank)).toEqual([
+				1, 2, 10
+			]);
+			expect(sortData(items as any[], 'rank' as any, 'desc').map((item: any) => item.rank)).toEqual(
+				[10, 2, 1]
+			);
+		});
+	});
+
+	describe('searchData', () => {
+		const items = [
+			{ title: 'Release Notes', tags: ['Svelte', 'API'], year: 2026, published: true },
+			{ title: 'Archive', tags: ['history'], year: 2024, published: false }
+		];
+
+		it('matches strings case-insensitively', () => {
+			expect(searchData(items, 'RELEASE', ['title'])).toEqual([items[0]]);
+		});
+
+		it('matches values nested in arrays', () => {
+			expect(searchData(items, 'api', ['tags'])).toEqual([items[0]]);
+		});
+
+		it('matches numeric values after string conversion', () => {
+			expect(searchData(items, '2024', ['year'])).toEqual([items[1]]);
+		});
+
+		it('ignores missing and falsy fields without throwing', () => {
+			expect(
+				searchData(items, 'true', ['published', 'missing' as keyof (typeof items)[number]])
+			).toEqual([items[0]]);
+		});
+	});
+});

--- a/src/lib/utils/helper.test.ts
+++ b/src/lib/utils/helper.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/i18n/i18n.svelte', () => ({
+	i18n: {
+		lang: 'en',
+		t: (key: string) =>
+			({
+				'duration.y': 'y',
+				'duration.mo': 'mo',
+				'duration.w': 'w',
+				'duration.d': 'd',
+				'duration.h': 'h',
+				'duration.m': 'm',
+				'duration.s': 's'
+			})[key] ?? key
+	}
+}));
+
+import { capitalize, disemvowel, formatDuration, hexToHsl, randomNumber } from './helper';
+
+describe('helper utilities', () => {
+	it('capitalizes text and handles an empty string', () => {
+		expect(capitalize('hello')).toBe('Hello');
+		expect(capitalize('')).toBe('');
+	});
+
+	it('removes vowels case-insensitively', () => {
+		expect(disemvowel('Muensterer')).toBe('Mnstrr');
+	});
+
+	it('keeps random numbers inside the inclusive range', () => {
+		vi.spyOn(Math, 'random').mockReturnValueOnce(0).mockReturnValueOnce(1);
+
+		expect(randomNumber(5, 10)).toBe(5);
+		expect(randomNumber(5, 10)).toBe(10);
+	});
+
+	it('formats sub-week durations using their non-zero units', () => {
+		const duration = 2 * 86_400_000 + 3 * 3_600_000 + 4 * 60_000 + 5_000;
+		expect(formatDuration(duration)).toBe('2d 3h 4m 5s');
+		expect(formatDuration(0)).toBe('0s');
+	});
+
+	it.each([
+		['#ff0000', '0 100% 50%'],
+		['#00ff00', '120 100% 50%'],
+		['#0000ff', '240 100% 50%'],
+		['#000000', '0 0% 0%'],
+		['#ffffff', '0 0% 100%']
+	])('converts %s to HSL', (hex, expected) => {
+		expect(hexToHsl(hex)).toBe(expected);
+	});
+});

--- a/src/lib/utils/helper.ts
+++ b/src/lib/utils/helper.ts
@@ -124,7 +124,9 @@ export function hexToHsl(hex: string): string {
 
 	// Calculate the hue (H) value
 	let hue = 0;
-	if (max === normalizedR) {
+	if (max === min) {
+		hue = 0;
+	} else if (max === normalizedR) {
 		hue = ((normalizedG - normalizedB) / (max - min) + 6) % 6;
 	} else if (max === normalizedG) {
 		hue = (normalizedB - normalizedR) / (max - min) + 2;


### PR DESCRIPTION
## What changed

- add direct unit coverage for API sorting and search behavior
- add expiry, deletion, and isolation tests for the in-memory gist cache
- add helper utility tests for formatting, random boundaries, and HSL conversion
- fix achromatic HSL conversion so black and white produce a numeric hue instead of `NaN`

## Why

The project had broad end-to-end coverage but limited direct coverage for reusable utility and server logic. These tests make edge-case regressions faster to identify and cheaper to diagnose.

## Impact

No intended user-facing behavior changes beyond correcting HSL conversion for achromatic colors.

## Validation

- `vitest`: 62 tests passed across 8 files
- focused new suite: 21 tests passed
- Prettier check passed
- `git diff --check` passed

The repository-wide Svelte type check continues to report unrelated pre-existing component and dependency diagnostics.
